### PR TITLE
Material Type Refactor

### DIFF
--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -30,4 +30,5 @@ jobs:
     - name: Install and Test MPACTPy
       run: |
         source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
+        pytest
         python -m pylint ./mpactpy

--- a/mpactpy/assembly.py
+++ b/mpactpy/assembly.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+from typing import Dict, List, Any, TypedDict
+from math import isclose
+
+from mpactpy.material import Material
+from mpactpy.pinmesh import PinMesh
+from mpactpy.pin import Pin
+from mpactpy.module import Module
+from mpactpy.lattice import Lattice
+from mpactpy.utils import list_to_str, unique
+
+
+class Assembly():
+    """ Assembly of an MPACT model
+
+    Attributes
+    ----------
+    id : int
+        The ID of the module
+    pitch : Dict[str, float]
+        The pitch of the lattice in the X-Y axis direction (keys: 'X', 'Y') (cm)
+    height : float
+        The total height of the assembly (cm)
+    nz : int
+        Number of modules along the z-dimension
+    mod_dim : ModDim
+        The x,y,z dimensions of the ray-tracing module
+    lattice_map : List[Lattice]
+        1-D array of lattice names
+    lattices : List[Lattice]
+        The unique lattices of this assembly
+    modules : List[Module]
+        The unique modules of this assembly
+    pins : List[Pin]
+        The unique pins of this assembly
+    pinmeshes : List[PinMesh]
+        The unique pin meshes of this assembly
+    materials : List[Material]
+        The materials of this module
+    """
+
+    class ModDim(TypedDict):
+        """ A Typed Dictionary class for Assembly Module Dimensions
+        """
+        X: float
+        Y: float
+        Z: List[float]
+
+    @property
+    def mpact_id(self) -> int:
+        return self._mpact_id
+
+    @mpact_id.setter
+    def mpact_id(self, mpact_id: int) -> None:
+        assert(mpact_id > 0), f"mpact_id = {mpact_id}"
+        self._mpact_id = mpact_id
+
+    @property
+    def pitch(self) -> Dict[str, float]:
+        return {'X': self.lattice_map[0].pitch['X'], 'Y': self.lattice_map[0].pitch['Y']}
+
+    @property
+    def height(self) -> float:
+        return self._height
+
+    @property
+    def nz(self) -> int:
+        return len(self.lattice_map)
+
+    @property
+    def mod_dim(self) -> ModDim:
+        return self._mod_dim
+
+    @property
+    def lattice_map(self) -> List[Lattice]:
+        return self._lattice_map
+
+    @property
+    def lattices(self) -> List[Lattice]:
+        return self._lattices
+
+    @property
+    def modules(self) -> List[Module]:
+        return self._modules
+
+    @property
+    def pins(self) -> List[Pin]:
+        return self._pins
+
+    @property
+    def pinmeshes(self) -> List[PinMesh]:
+        return self._pinmeshes
+
+    @property
+    def materials(self) -> List[Material]:
+        return self._materials
+
+    def __init__(self, lattice_map: List[Lattice], mpact_id: int = 1):
+        assert len(lattice_map) > 0
+
+        self.mpact_id     = mpact_id
+        self._lattice_map = lattice_map
+        self.set_unique_elements()
+
+        assert all(isclose(lattice.mod_dim['X'], self.lattices[0].mod_dim['X']) for lattice in self.lattices)
+        assert all(isclose(lattice.mod_dim['Y'], self.lattices[0].mod_dim['Y']) for lattice in self.lattices)
+        assert all(lattice.nx == self.lattices[0].nx for lattice in self.lattices)
+        assert all(lattice.ny == self.lattices[0].ny for lattice in self.lattices)
+
+        self._pitch  = {'X': self.lattices[0].pitch['X'],
+                        'Y': self.lattices[0].pitch['Y']}
+
+        self._height = sum(self.lattice_map[i].pitch['Z'] for i in range(self.nz))
+
+        unique_lattice_heights = []
+        for lattice in self.lattices:
+            if not any(isclose(lattice.pitch['Z'], unique_height) for unique_height in unique_lattice_heights):
+                unique_lattice_heights.append(lattice.pitch['Z'])
+        unique_lattice_heights = sorted(unique_lattice_heights)
+
+        self._mod_dim = {'X': self.lattices[0].mod_dim['X'],
+                         'Y': self.lattices[0].mod_dim['Y'],
+                         'Z': unique_lattice_heights}
+
+    def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
+        return (isinstance(other, Assembly)     and
+                self.lattice_map == other.lattice_map
+               )
+
+    def __hash__(self) -> int:
+        return hash(tuple(self.lattice_map))
+
+    def write_to_string(self, prefix: str = "") -> str:
+        """ Method for writing a to a string
+
+        Parameter
+        ---------
+        prefix : str
+            A prefix with which to start each line of the written output string
+
+        Returns
+        -------
+        str
+            The string that represents the
+        """
+
+        string = prefix + f"assembly {self.mpact_id}\n"
+        lattices = [lattice.mpact_id for lattice in self.lattice_map]
+        string += prefix + prefix + f"{list_to_str(lattices)}\n"
+        return string
+
+    def set_unique_elements(self, other_lattices: List[Lattice] = []) -> None:
+        """ Determines and sets the unique elements of the assembly
+
+        Parameters
+        ----------
+        other_lattices : List[Lattice]
+            The lattices from other assemblies which should be considered as already defined
+        """
+        # NOTE: To get the ordering correct, other_lattices must by left-hand-side added to the map list
+        already_defined_lattices  = unique(other_lattices + self.lattice_map)
+        already_defined_modules   = unique([module for lattice in already_defined_lattices for module in lattice.modules])
+
+        for i, _ in enumerate(self.lattice_map):
+            self.lattice_map[i].set_unique_elements(already_defined_modules)
+            self._lattice_map[i] = next(lattice for lattice in already_defined_lattices if self.lattice_map[i] == lattice)
+
+        self._lattices  = unique(self.lattice_map)
+        self._modules   = unique([module for lattice in self.lattices for module in lattice.modules])
+        self._pins      = unique([pin for module in self.modules for pin in module.pins])
+        self._pinmeshes = unique([pin.pinmesh for pin in self.pins])
+        self._materials = unique([material for pin in self.pins for material in pin.materials])
+
+
+    def get_axial_slice(self, start_pos: float, stop_pos: float) -> Assembly:
+        """ Method for creating a new Assembly from an axial slice of this Assembly
+
+        Parameters
+        ----------
+        start_pos : float
+            The starting axial position of the slice
+        stop_pos : float
+            The stopping axial position of the slice
+
+        Returns
+        -------
+        Assembly
+            The new Assembly created from the axial slice
+        """
+
+        assert stop_pos > start_pos
+
+        if stop_pos  <= 0.          or isclose(stop_pos,  0.) or \
+           start_pos >= self.height or isclose(start_pos, self.height):
+            return None
+
+        start_pos = max(0,           start_pos)
+        stop_pos  = min(self.height, stop_pos)
+
+        z0 = 0.
+        lattice_map = []
+        for lattice in self.lattice_map:
+            lattice_slice = lattice.get_axial_slice(start_pos-z0, stop_pos-z0)
+            if lattice_slice:
+                lattice_map.append(lattice_slice)
+            z0 += lattice.pitch["Z"]
+
+        return Assembly(lattice_map)

--- a/mpactpy/core.py
+++ b/mpactpy/core.py
@@ -286,18 +286,19 @@ class Core():
         all_points = [0.0] + sorted([x for mesh in meshes for x in mesh])
         unionized_mesh = [all_points[0]]
         for point in all_points[1:]:
-            if not(isclose(point, unionized_mesh[-1])):
+            if not isclose(point, unionized_mesh[-1]):
                 unionized_mesh.append(point)
 
         for i in range(1, len(unionized_mesh)):
             if unionized_mesh[i] - unionized_mesh[i-1] < min_thickness:
-                raise RuntimeError("Axial Mesh Unionization results in a mesh element less than the minimum thickness limit: " +\
+                raise RuntimeError("Axial Mesh Unionization results in a mesh element " + \
+                                   "less than the minimum thickness limit: " +\
                                    f"{min_thickness} starting at axial position: {unionized_mesh[i-1]}")
 
         unionized_assemblies = []
         for assembly in self.assemblies:
             unionized_assemblies.append(None)
-            if not(assembly is None):
+            if not assembly is None:
                 lattice_map = []
                 for start_pos, stop_pos in zip(unionized_mesh[:-1], unionized_mesh[1:]):
                     lattice_map.extend(assembly.get_axial_slice(start_pos, stop_pos).lattice_map)

--- a/mpactpy/core.py
+++ b/mpactpy/core.py
@@ -167,7 +167,7 @@ class Core():
         string += "\n"
         for row in self.assembly_map:
             assemblies = [assembly.mpact_id if assembly is not None else "" for assembly in row]
-            string += prefix + f"  {list_to_str(assemblies, id_length)}\n"
+            string += prefix + f"  {list_to_str(assemblies, id_length).rstrip()}\n"
         return string
 
     def set_unique_elements(self, other_assemblies: List[Assembly] = []) -> None:

--- a/mpactpy/core.py
+++ b/mpactpy/core.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+from typing import List, Any, Literal
+from math import isclose
+
+from mpactpy.material import Material
+from mpactpy.pinmesh import PinMesh
+from mpactpy.pin import Pin
+from mpactpy.module import Module
+from mpactpy.lattice import Lattice
+from mpactpy.assembly import Assembly
+from mpactpy.utils import list_to_str, is_rectangular, unique
+
+
+class Core():
+    """ Core of an MPACT model
+
+    Attributes
+    ----------
+    symmetry_opt : SymmetryOption
+        Core symmetry ("360", "90")
+    quarter_sym_opt : QuarterSymmetryOption
+        Quarter core centerline symmetry
+        (i.e. whether the centerline bisects an assembly through the
+        center, or passes between assemblies along the edge)
+    nx : int
+        Number of modules along the x-dimension
+    ny : int
+        Number of modules along the y-dimension
+    nz : int
+        Number of modules along the z-dimension
+    height : float
+        The total height of the core (cm)
+    mod_dim : Assembly.ModDim
+        The x,y,z dimensions of the ray-tracing module
+    assembly_map : List[List[Assembly]]
+        2-D map of the core assemblies
+    assemblies : List[Assembly]
+        The unique assemblies of this core
+    lattices : List[Lattice]
+        The unique lattices of this core
+    modules : List[Module]
+        The unique modules of this core
+    pins : List[Pin]
+        The unique pins of this core
+    pinmeshes : List[PinMesh]
+        The unique pin meshes of this core
+    materials : List[Material]
+        The materials of this module
+    """
+
+    SymmetryOption = Literal["360", "90", ""]
+    QuarterSymmetryOption = Literal["EDGE", "CENT", ""]
+
+    @property
+    def symmetry_opt(self) -> SymmetryOption:
+        return self._symmetry_opt
+
+    @property
+    def quarter_sym_opt(self) -> QuarterSymmetryOption:
+        return self._quarter_sym_opt
+
+    @property
+    def nx(self) -> int:
+        return len(self.assembly_map)
+
+    @property
+    def ny(self) -> int:
+        return len(self.assembly_map[0])
+
+    @property
+    def nz(self) -> int:
+        return self.assemblies[0].nz
+
+    @property
+    def height(self) -> float:
+        return self.assemblies[0].height
+
+    @property
+    def mod_dim(self) -> Assembly.ModDim:
+        return self.assemblies[0].mod_dim
+
+    @property
+    def assembly_map(self) -> List[List[Assembly]]:
+        return self._assembly_map
+
+    @property
+    def assemblies(self) -> List[Assembly]:
+        return self._assemblies
+
+    @property
+    def lattices(self) -> List[Lattice]:
+        return self._lattices
+
+    @property
+    def modules(self) -> List[Module]:
+        return self._modules
+
+    @property
+    def pins(self) -> List[Pin]:
+        return self._pins
+
+    @property
+    def pinmeshes(self) -> List[PinMesh]:
+        return self._pinmeshes
+
+    @property
+    def materials(self) -> List[Material]:
+        return self._materials
+
+
+    def __init__(self,
+                 assembly_map: List[List[Assembly]],
+                 symmetry_opt: SymmetryOption = "",
+                 quarter_sym_opt: QuarterSymmetryOption = ""):
+
+        assert is_rectangular(assembly_map)
+
+        self._symmetry_opt    = symmetry_opt
+        self._quarter_sym_opt = quarter_sym_opt
+        self._assembly_map    = assembly_map
+        self.set_unique_elements()
+
+        assert len(self.assemblies) > 0
+
+        assert all(isclose(assembly.mod_dim['X'], self.mod_dim['X']) for assembly in self.assemblies)
+        assert all(isclose(assembly.mod_dim['Y'], self.mod_dim['Y']) for assembly in self.assemblies)
+        assert all(assembly.nz == self.assemblies[0].nz for assembly in self.assemblies)
+        assert self._assemblies_have_same_axial_spacing()
+        assert self._assembly_map_is_radially_internally_continuous()
+
+    def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
+        return (isinstance(other, Core)                       and
+                self.symmetry_opt    == other.symmetry_opt    and
+                self.quarter_sym_opt == other.quarter_sym_opt and
+                self.assembly_map    == other.assembly_map
+               )
+
+    def __hash__(self) -> int:
+        return hash((self.symmetry_opt,
+                    self.quarter_sym_opt,
+                    tuple(tuple(row) for row in self.assembly_map)))
+
+    def write_to_string(self, prefix: str = "") -> str:
+        """ Method for writing a to a string
+
+        Parameter
+        ---------
+        prefix : str
+            A prefix with which to start each line of the written output string
+
+        Returns
+        -------
+        str
+            The string that represents the
+        """
+
+        id_length = max(len(str(assembly.mpact_id)) if assembly is not None else 0
+                        for row in self.assembly_map for assembly in row)
+
+        string = prefix + "core"
+        if len(self.symmetry_opt)    > 0:
+            string += f" {self.symmetry_opt}"
+        if len(self.quarter_sym_opt) > 0:
+            string += f" {self.quarter_sym_opt}"
+        string += "\n"
+        for row in self.assembly_map:
+            assemblies = [assembly.mpact_id if assembly is not None else "" for assembly in row]
+            string += prefix + f"  {list_to_str(assemblies, id_length)}\n"
+        return string
+
+    def set_unique_elements(self, other_assemblies: List[Assembly] = []) -> None:
+        """ Determines and sets the unique elements of the core
+
+        Parameters
+        ----------
+        already_defined_assemblies : List[Assembly]
+            The assemblies which should be considered as already defined
+        """
+        # NOTE: To get the ordering correct, other_assemblies must by left-hand-side added to the map list
+        already_defined_assemblies = other_assemblies + [assembly for row in self.assembly_map
+                                                         for assembly in row if assembly is not None]
+        already_defined_assemblies = {assembly: i+1 for i, assembly in enumerate(unique(already_defined_assemblies))}
+        for assembly, mpact_id in already_defined_assemblies.items():
+            assembly.mpact_id = mpact_id
+
+        self._assemblies = list(already_defined_assemblies)
+        self._lattices   = unique([lattice for assembly in self.assemblies for lattice in assembly.lattice_map])
+        self._modules    = unique([module for lattice in self.lattices for row in lattice.module_map for module in row])
+        self._pins       = unique([pin for module in self.modules for row in module.pin_map for pin in row])
+        self._pinmeshes  = unique([pin.pinmesh for pin in self.pins])
+        self._materials  = unique([material for pin in self.pins for material in pin.materials])
+        for assembly in self.assemblies:
+            assembly.set_unique_elements(self.lattices)
+
+        for i, _ in enumerate(self.assembly_map):
+            for j, _ in enumerate(self.assembly_map[i]):
+                self._assembly_map[i][j] = None if self.assembly_map[i][j] is None else \
+                                           next(assembly for assembly in self.assemblies
+                                                if self.assembly_map[i][j] == assembly)
+
+
+    def _assemblies_have_same_axial_spacing(self)->bool:
+        """ A helper method for checking that all assemblies have the same axial spacing along their lengths
+        """
+
+        for assembly in self.assemblies:
+            for i in range(assembly.nz):
+                if not isclose(assembly.lattice_map[i].pitch['Z'], self.assemblies[0].lattice_map[i].pitch['Z']):
+                    return False
+        return True
+
+    def _assembly_map_is_radially_internally_continuous(self) -> bool:
+        """ A helper method for checking the core assembly map is internally continuous
+
+        This method allows for "stair-case" core boundaries, but does not allow for missing
+        assemblies within the core boundaries, or inconsistent assembly pitches along each
+        row and column
+        """
+
+        def is_continuous_line(line, axis):
+            prev_assemblies = []
+            pitch = None
+
+            for assembly in line:
+                if assembly is not None:
+
+                    # Check for inconsistent pitch
+                    current_pitch = assembly.pitch[axis]
+                    if pitch is not None and not isclose(current_pitch, pitch):
+                        return False
+                    pitch = current_pitch
+
+                    # Check for holes in the line
+                    if len(prev_assemblies) > 2 and prev_assemblies[-1] is None and prev_assemblies[-2] is not None:
+                        return False
+
+                prev_assemblies.append(assembly)
+            return True
+
+        # Check rows
+        for row in self.assembly_map:
+            if not is_continuous_line(row, 'Y'):
+                return False
+
+        # Check columns
+        for j in range(self.ny):
+            column = [self.assembly_map[i][j] for i in range(self.nx)]
+            if not is_continuous_line(column, 'X'):
+                return False
+
+        return True
+
+    def get_axial_slice(self, start_pos: float, stop_pos: float) -> Core:
+        """ Method for creating a new Core from an axial slice of this Core
+
+        Parameters
+        ----------
+        start_pos : float
+            The starting axial position of the slice
+        stop_pos : float
+            The stopping axial position of the slice
+
+        Returns
+        -------
+        Core
+            The new Core created from the axial slice
+        """
+
+        assert stop_pos > start_pos
+
+        if stop_pos  <= 0.          or isclose(stop_pos,  0.) or \
+           start_pos >= self.height or isclose(start_pos, self.height):
+            return None
+
+        start_pos = max(0,           start_pos)
+        stop_pos  = min(self.height, stop_pos)
+
+        assembly_map = [[assembly.get_axial_slice(start_pos, stop_pos) if assembly else None
+                         for assembly in row] for row in self.assembly_map]
+
+        return Core(assembly_map, self.symmetry_opt, self.quarter_sym_opt)

--- a/mpactpy/core.py
+++ b/mpactpy/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import List, Any, Literal, Dict
 from math import isclose
+from itertools import accumulate
 
 from mpactpy.material import Material
 from mpactpy.pinmesh import PinMesh
@@ -14,6 +15,22 @@ from mpactpy.utils import list_to_str, is_rectangular, unique
 class Core():
     """ Core of an MPACT model
 
+    Parameters
+    ----------
+    assembly_map : List[List[Assembly]]
+        2-D map of the core assemblies
+    symmetry_opt : SymmetryOption
+        Core symmetry ("360", "90")
+    quarter_sym_opt : QuarterSymmetryOption
+        Quarter core centerline symmetry
+        (i.e. whether the centerline bisects an assembly through the
+        center, or passes between assemblies along the edge)
+    min_thickness: float
+        The minimum allowed thickness for unionization.  If the unionized mesh
+        produces a mesh element with an axial height less than the minimum thickness,
+        an error will be thrown.  This is meant as a failsafe for applications in which
+        a minimum axial thickness is required.
+
     Attributes
     ----------
     symmetry_opt : SymmetryOption
@@ -23,9 +40,9 @@ class Core():
         (i.e. whether the centerline bisects an assembly through the
         center, or passes between assemblies along the edge)
     nx : int
-        Number of modules along the x-dimension
+        Number of assemblies along the x-dimension
     ny : int
-        Number of modules along the y-dimension
+        Number of assemblies along the y-dimension
     nz : int
         Number of modules along the z-dimension
     height : float
@@ -111,7 +128,8 @@ class Core():
     def __init__(self,
                  assembly_map: List[List[Assembly]],
                  symmetry_opt: SymmetryOption = "",
-                 quarter_sym_opt: QuarterSymmetryOption = ""):
+                 quarter_sym_opt: QuarterSymmetryOption = "",
+                 min_thickness: float = 0.):
 
         assert is_rectangular(assembly_map)
 
@@ -120,19 +138,22 @@ class Core():
         self._assembly_map    = assembly_map
 
         self._assemblies = unique(assembly for row in self.assembly_map for assembly in row if assembly)
-        self._lattices   = unique(lattice for assembly in self.assemblies for lattice in assembly.lattice_map)
-        self._modules    = unique(module for lattice in self.lattices for row in lattice.module_map for module in row)
-        self._pins       = unique(pin for module in self.modules for row in module.pin_map for pin in row)
-        self._pinmeshes  = unique(pin.pinmesh for pin in self.pins)
-        self._materials  = unique(material for pin in self.pins for material in pin.materials)
 
         assert len(self.assemblies) > 0
 
         assert all(isclose(assembly.mod_dim['X'], self.mod_dim['X']) for assembly in self.assemblies)
         assert all(isclose(assembly.mod_dim['Y'], self.mod_dim['Y']) for assembly in self.assemblies)
-        assert all(assembly.nz == self.assemblies[0].nz for assembly in self.assemblies)
-        assert self._assemblies_have_same_axial_spacing()
         assert self._assembly_map_is_radially_internally_continuous()
+
+        assert all(isclose(assembly.height, self.assemblies[0].height) for assembly in self.assemblies if assembly)
+        if not self._assemblies_have_same_axial_meshing():
+            self._unionize_axial_mesh(min_thickness)
+
+        self._lattices   = unique(lattice for assembly in self.assemblies for lattice in assembly.lattice_map)
+        self._modules    = unique(module for lattice in self.lattices for row in lattice.module_map for module in row)
+        self._pins       = unique(pin for module in self.modules for row in module.pin_map for pin in row)
+        self._pinmeshes  = unique(pin.pinmesh for pin in self.pins)
+        self._materials  = unique(material for pin in self.pins for material in pin.materials)
 
     def __eq__(self, other: Any) -> bool:
         if self is other:
@@ -184,9 +205,16 @@ class Core():
             string += prefix + f"  {list_to_str(assemblies, id_length).rstrip()}\n"
         return string
 
-    def _assemblies_have_same_axial_spacing(self)->bool:
-        """ A helper method for checking that all assemblies have the same axial spacing along their lengths
+    def _assemblies_have_same_axial_meshing(self)->bool:
+        """ A helper method for checking if all assemblies have the same axial axial meshing along their lengths
+
+        Returns
+        -------
+        True if all assemblies have the same axial meshing, False otherwise
         """
+
+        if any(assembly.nz != self.assemblies[0].nz for assembly in self.assemblies):
+            return False
 
         for assembly in self.assemblies:
             for i in range(assembly.nz):
@@ -200,6 +228,10 @@ class Core():
         This method allows for "stair-case" core boundaries, but does not allow for missing
         assemblies within the core boundaries, or inconsistent assembly pitches along each
         row and column
+
+        Returns
+        -------
+        True if the assembly map is radially internally continuous, False otherwise
         """
 
         def is_continuous_line(line, axis):
@@ -234,6 +266,53 @@ class Core():
                 return False
 
         return True
+
+    def _unionize_axial_mesh(self, min_thickness: float = 0.) -> None:
+        """ Helper method that unionizes the axial meshes of the core assemblies
+
+        This method currently only supports cases where all pinmeshes have a single axial material division
+
+        Parameters
+        ----------
+        min_thickness: float
+            The minimum allowed thickness for unionization.  If the unionized mesh
+            produces a mesh element with an axial height less than the minimum thickness,
+            an error will be thrown.  This is meant as a failsafe for applications in which
+            a minimum axial thickness is required.
+        """
+
+        meshes = [list(accumulate(lattice.pitch["Z"] for lattice in assembly.lattice_map)) for assembly in self.assemblies]
+
+        all_points = [0.0] + sorted([x for mesh in meshes for x in mesh])
+        unionized_mesh = [all_points[0]]
+        for point in all_points[1:]:
+            if not(isclose(point, unionized_mesh[-1])):
+                unionized_mesh.append(point)
+
+        for i in range(1, len(unionized_mesh)):
+            if unionized_mesh[i] - unionized_mesh[i-1] < min_thickness:
+                raise RuntimeError("Axial Mesh Unionization results in a mesh element less than the minimum thickness limit: " +\
+                                   f"{min_thickness} starting at axial position: {unionized_mesh[i-1]}")
+
+        unionized_assemblies = []
+        for assembly in self.assemblies:
+            unionized_assemblies.append(None)
+            if not(assembly is None):
+                lattice_map = []
+                for start_pos, stop_pos in zip(unionized_mesh[:-1], unionized_mesh[1:]):
+                    lattice_map.extend(assembly.get_axial_slice(start_pos, stop_pos).lattice_map)
+                unionized_assemblies[-1] = Assembly(lattice_map)
+
+        # This effectively creates a mapping between unionized assemblies and their original unique assembly counterparts
+        orig_to_unionized = dict(zip(self.assemblies, unionized_assemblies))
+
+        self._assembly_map = [[orig_to_unionized[assembly] if not(assembly is None) else None
+                               for assembly in row] for row in self._assembly_map]
+
+        self._assemblies = unique(unionized_assemblies)
+
+        assert self._assemblies_have_same_axial_meshing()
+
 
     def get_axial_slice(self, start_pos: float, stop_pos: float) -> Core:
         """ Method for creating a new Core from an axial slice of this Core

--- a/mpactpy/lattice.py
+++ b/mpactpy/lattice.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+from typing import Dict, List, Any
+from math import isclose
+
+from mpactpy.material import Material
+from mpactpy.pinmesh import PinMesh
+from mpactpy.pin import Pin
+from mpactpy.module import Module
+from mpactpy.utils import list_to_str, unique, is_rectangular
+
+
+class Lattice():
+    """  Lattice of an MPACT model
+
+    Attributes
+    ----------
+    id : int
+        The ID of the module
+    nx : int
+        Number of modules along the x-dimension
+    ny : int
+        Number of modules along the y-dimension
+    pitch : Dict[str, float]
+        The pitch of the lattice in each axis direction (keys: 'X', 'Y', 'Z') (cm)
+    mod_dim : Dict[str, float]
+        The x,y dimensions of the ray-tracing module
+    module_map : List[List[Module]]
+        a 2-D array of modules
+    modules : List[Module]
+        The unique modules of this lattice
+    pins : List[Pin]
+        The unique pins of this lattice
+    pinmeshes : List[PinMesh]
+        The unique pin meshes of this lattice
+    materials : List[Material]
+        The materials of this module
+    """
+
+    @property
+    def mpact_id(self) -> int:
+        return self._mpact_id
+
+    @mpact_id.setter
+    def mpact_id(self, mpact_id: int) -> None:
+        assert(mpact_id > 0), f"mpact_id = {mpact_id}"
+        self._mpact_id = mpact_id
+
+    @property
+    def nx(self) -> int:
+        return len(self.module_map)
+
+    @property
+    def ny(self) -> int:
+        return len(self.module_map[0])
+
+    @property
+    def pitch(self) -> Dict[str, float]:
+        return self._pitch
+
+    @property
+    def mod_dim(self) -> Dict[str, float]:
+        return self._mod_dim
+
+    @property
+    def module_map(self) -> List[List[Module]]:
+        return self._module_map
+
+    @property
+    def modules(self) -> List[Module]:
+        return self._modules
+
+    @property
+    def pins(self) -> List[Pin]:
+        return self._pins
+
+    @property
+    def pinmeshes(self) -> List[PinMesh]:
+        return self._pinmeshes
+
+    @property
+    def materials(self) -> List[Material]:
+        return self._materials
+
+    def __init__(self, module_map: List[List[Module]], mpact_id: int = 1):
+        assert is_rectangular(module_map)
+
+        self.mpact_id    = mpact_id
+        self._module_map = module_map
+        self.set_unique_elements()
+        self._mod_dim    = {'X': self.modules[0].pitch['X'], 'Y': self.modules[0].pitch['Y']}
+
+        assert all(isclose(self.module_map[i][j].pitch['X'], self.mod_dim['X'])
+                   for j in range(self.ny) for i in range(self.nx))
+
+        assert all(isclose(self.module_map[i][j].pitch['Y'], self.mod_dim['Y'])
+                   for i in range(self.nx) for j in range(self.ny))
+
+        assert all(isclose(module.pitch['Z'], self.modules[0].pitch['Z']) for module in self.modules)
+
+        self._pitch   = {'X': self.mod_dim['X'] * self.nx,
+                         'Y': self.mod_dim['Y'] * self.ny,
+                         'Z': self.modules[0].pitch['Z']}
+
+    def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
+        return (isinstance(other, Lattice)     and
+                self.module_map == other.module_map
+               )
+
+    def __hash__(self) -> int:
+        return hash(tuple(tuple(row) for row in self.module_map))
+
+    def write_to_string(self, prefix: str = "") -> str:
+        """ Method for writing a lattice to a string
+
+        Parameter
+        ---------
+        prefix : str
+            A prefix with which to start each line of the written output string
+
+        Returns
+        -------
+        str
+            The string that represents the lattice
+        """
+
+        id_length = max(len(str(module.mpact_id)) for row in self.module_map for module in row)
+
+        string = prefix + f"lattice {self.mpact_id} {self.nx} {self.ny}\n"
+        for row in self.module_map:
+            modules = [module.mpact_id for module in row]
+            string += prefix + prefix + f"{list_to_str(modules, id_length)}\n"
+        return string
+
+    def set_unique_elements(self, other_modules: List[Module] = []) -> None:
+        """ Determines and sets the unique elements of the lattice
+
+        Parameters
+        ----------
+        other_modules : List[Modules]
+            The modules from other lattices which should be considered as already defined
+        """
+        # NOTE: To get the ordering correct, other_modules must by left-hand-side added to the map list
+        already_defined_modules   = unique(other_modules + [module for row in self.module_map for module in row])
+        already_defined_pins      = unique([pin for module in already_defined_modules for pin in module.pins])
+
+        for i, _ in enumerate(self.module_map):
+            for j, _ in enumerate(self.module_map[i]):
+                self.module_map[i][j].set_unique_elements(already_defined_pins)
+                self._module_map[i][j] = next(module for module in already_defined_modules
+                                              if self.module_map[i][j] == module)
+
+        self._modules   = unique([module for row in self.module_map for module in row])
+        self._pins      = unique([pin for module in self.modules for pin in module.pins])
+        self._pinmeshes = unique([pin.pinmesh for pin in self.pins])
+        self._materials = unique([material for pin in self.pins for material in pin.materials])
+
+    def get_axial_slice(self, start_pos: float, stop_pos: float) -> Lattice:
+        """ Method for creating a new Lattice from an axial slice of this Lattice
+
+        Parameters
+        ----------
+        start_pos : float
+            The starting axial position of the slice
+        stop_pos : float
+            The stopping axial position of the slice
+
+        Returns
+        -------
+        Lattice
+            The new Lattice created from the axial slice
+        """
+
+        assert stop_pos > start_pos
+
+        if stop_pos  <= 0.              or isclose(stop_pos,  0.) or \
+           start_pos >= self.pitch["Z"] or isclose(start_pos, self.pitch["Z"]):
+            return None
+
+        start_pos = max(0,               start_pos)
+        stop_pos  = min(self.pitch["Z"], stop_pos)
+
+        module_map = [[module.get_axial_slice(start_pos, stop_pos) for module in row] for row in self.module_map]
+
+        return Lattice(module_map)

--- a/mpactpy/material.py
+++ b/mpactpy/material.py
@@ -48,7 +48,7 @@ class Material():
 
     @mpact_id.setter
     def mpact_id(self, mpact_id: int) -> None:
-        assert mpact_id > 0
+        assert mpact_id > 0, f"mpact_id = {mpact_id}"
         self._mpact_id = mpact_id
 
     @property
@@ -82,11 +82,13 @@ class Material():
 
         thermal_scattering_isotopes = [] if thermal_scattering_isotopes is None else thermal_scattering_isotopes
 
-        assert material_type in VALID_MATERIAL_TYPES
-        assert density >= 0.
-        assert temperature >= 0.
-        assert all(number_dens >= 0. for number_dens in number_densities.values())
-        assert all(iso in number_densities for iso in thermal_scattering_isotopes)
+        assert material_type in VALID_MATERIAL_TYPES, f"material_type = {material_type}"
+        assert density >= 0., f"density = {density}"
+        assert temperature >= 0., f"temperature = {temperature}"
+        assert all(number_dens >= 0. for number_dens in number_densities.values()), \
+            f"number_densities = {number_densities}"
+        assert all(iso in number_densities for iso in thermal_scattering_isotopes), \
+            f"thermal_scattering_isotopes = {thermal_scattering_isotopes}"
 
         self.mpact_id                     = mpact_id
         self._material_type               = material_type
@@ -151,8 +153,8 @@ class Material():
             The MPACT Model material created from the OpenMC Material
         """
 
-        assert material_type in VALID_MATERIAL_TYPES
-        assert material.density_units in ['g/cc', 'g/cm3']
+        assert material_type in VALID_MATERIAL_TYPES, f"material_type = {material_type}"
+        assert material.density_units in ['g/cc', 'g/cm3'], f"density_units = {material.density_units}"
 
         number_densities = {}
         for iso in thermal_scattering_isotopes:

--- a/mpactpy/material.py
+++ b/mpactpy/material.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Any
 from math import isclose
 import openmc
 
-from mpactpy.utils import relative_round
+from mpactpy.utils import relative_round, ROUNDING_RELATIVE_TOLERANCE as TOL
 
 
 class Material():
@@ -97,26 +97,24 @@ class Material():
 
 
     def __eq__(self, other: Any) -> bool:
-        tol = 1E-5
         if self is other:
             return True
         return (isinstance(other, Material)                                           and
                 self.material_type == other.material_type                             and
-                isclose(self.density, other.density, rel_tol=tol)                     and
-                isclose(self.temperature, other.temperature, rel_tol=tol)             and
+                isclose(self.density, other.density, rel_tol=TOL)                     and
+                isclose(self.temperature, other.temperature, rel_tol=TOL)             and
                 self.number_densities.keys() == other.number_densities.keys()         and
                 self.thermal_scattering_isotopes == other.thermal_scattering_isotopes and
-                all(isclose(self.number_densities[iso], other.number_densities[iso], rel_tol=tol)
+                all(isclose(self.number_densities[iso], other.number_densities[iso], rel_tol=TOL)
                     for iso in self.number_densities.keys())
                 )
 
     def __hash__(self) -> int:
-        tol = 1E-5
-        number_densities = sorted({iso: relative_round(numd, tol)
+        number_densities = sorted({iso: relative_round(numd, TOL)
                                    for iso, numd in self.number_densities.items()})
         return hash((self.material_type,
-                     relative_round(self.density, tol),
-                     relative_round(self.temperature, tol),
+                     relative_round(self.density, TOL),
+                     relative_round(self.temperature, TOL),
                      tuple(number_densities),
                      tuple(self.thermal_scattering_isotopes)))
 

--- a/mpactpy/model.py
+++ b/mpactpy/model.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+from typing import List, Dict, Any
+
+from mpactpy.material import Material
+from mpactpy.pinmesh import PinMesh
+from mpactpy.pin import Pin
+from mpactpy.module import Module
+from mpactpy.lattice import Lattice
+from mpactpy.assembly import Assembly
+from mpactpy.core import Core
+from mpactpy.utils import list_to_str
+
+
+
+class Model():
+    """ An input writer for MPACT
+
+    It should noted that MPACT Model does not allow for repeated geometry
+    element definitions.  This means that redudant geometry elements
+    (i.e. geometry elements that are identical to some previously defined geometry
+    element in all features except ID) are purged.
+
+    Attributes
+    ----------
+    materials : List[Material]
+        The model materials
+    states : List[Dict[str, str]]
+        The model states
+    pinmeshes : List[PinMesh]
+        The model pinmeshes
+    pins : List[Pin]
+        The model pins
+    modules : List[Module]
+        The model modules
+    lattices : List[Lattice]
+        The model lattices
+    assemblies : List[Assembly]
+        The model assemblies
+    core : Core
+        The model core
+    mod_dim : Assembly.ModDim
+        The x,y,z dimensions of the ray-tracing module
+    xsec_settings : Dict[str, str]
+        The model cross-section settings
+    options : Dict[str, str]
+        The model options
+    """
+
+    @property
+    def materials(self) -> List[Material]:
+        return self.core.materials
+
+    @property
+    def states(self) -> List[Dict[str, str]]:
+        return self._states
+
+    @property
+    def pinmeshes(self) -> List[PinMesh]:
+        return self.core.pinmeshes
+
+    @property
+    def pins(self) -> List[Pin]:
+        return self.core.pins
+
+    @property
+    def modules(self) -> List[Module]:
+        return self.core.modules
+
+    @property
+    def lattices(self) -> List[Lattice]:
+        return self.core.lattices
+
+    @property
+    def assemblies(self) -> List[Assembly]:
+        return self.core.assemblies
+
+    @property
+    def core(self) -> Core:
+        return self._core
+
+    @property
+    def mod_dim(self) -> Assembly.ModDim:
+        return self.core.mod_dim
+
+    @property
+    def xsec_settings(self) -> Dict[str, str]:
+        return self._xsec_settings
+
+    @property
+    def options(self) -> Dict[str, str]:
+        return self._options
+
+
+    def __init__(self,
+                 core          : Core,
+                 states        : List[Dict[str, str]],
+                 xsec_settings : Dict[str, str],
+                 options       : Dict[str, str]
+    ):
+        self._core          = core
+        self._states        = states
+        self._xsec_settings = xsec_settings
+        self._options       = options
+
+    def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
+        return (isinstance(other, Model)                  and
+                self.core          == other.core          and
+                self.states        == other.states        and
+                self.xsec_settings == other.xsec_settings and
+                self.options       == other.options
+               )
+
+    def __hash__(self) -> int:
+        return hash((self.core,
+                    tuple(tuple(state.items()) for state in self.states),
+                    tuple(self.xsec_settings.items()),
+                    tuple(self.options.items())))
+
+    def write_to_string(self, caseid: str, indent: int) -> str:
+        """ Writes an MPACT input file of the model
+
+        Parameters
+        ----------
+        caseid : str
+            The CASEID of this input
+        indent : int
+            The length of line indentations
+
+        Returns
+        -------
+        str
+            The MPACT input file as a string
+        """
+
+        assert indent > 0
+
+        prefix = "".ljust(indent)
+
+        string = f"CASEID {caseid}\n\n"
+
+        string += "MATERIAL\n"
+        for material in self.materials:
+            string += material.write_to_string(prefix)
+        string += "\n"
+
+        for state in self.states:
+            string += "STATE"
+            for param, val in state.items():
+                string += " " + param + " " + val
+            string += "\n"
+        string += "\n"
+
+        string += "GEOM\n"
+        string += prefix + f"mod_dim {self.mod_dim['X']} {self.mod_dim['Y']} {list_to_str(self.mod_dim['Z'])}\n\n"
+
+        for pinmesh in self.pinmeshes:
+            string += pinmesh.write_to_string(prefix)
+        string += "\n"
+
+        for pin in self.pins:
+            string += pin.write_to_string(prefix)
+        string += "\n"
+
+        for module in self.modules:
+            string += module.write_to_string(prefix)
+        string += "\n"
+
+        for lattice in self.lattices:
+            string += lattice.write_to_string(prefix)
+        string += "\n"
+
+        for assembly in self.assemblies:
+            string += assembly.write_to_string(prefix)
+        string += "\n"
+
+        string += self.core.write_to_string(prefix) + "\n"
+
+        string += "XSEC\n"
+        for setting, argument in sorted(self.xsec_settings.items()):
+            string += prefix + f"{setting} {argument}\n"
+        string += "\n"
+
+        string += "OPTION\n"
+        for setting, argument in sorted(self.options.items()):
+            string += prefix + f"{setting} {argument}\n"
+        string += "\n"
+
+        return string
+
+    @staticmethod
+    def read_from_string(string_to_read: str) -> Model:
+        """ Function for reading an MPACT input file from a string into a model
+
+        Parameters
+        ----------
+        string_to_read : str
+            string representing the mpact input file to be read
+
+        Returns
+        -------
+            The MPACTModel created from the input file string
+        """
+
+        raise NotImplementedError("This method is not yet implemented.")

--- a/mpactpy/module.py
+++ b/mpactpy/module.py
@@ -109,7 +109,7 @@ class Module():
 
     def __hash__(self) -> int:
         return hash((self.nz,
-                     tuple([tuple(row) for row in self.pin_map])))
+                     tuple(tuple(row) for row in self.pin_map)))
 
     def write_to_string(self, prefix: str = "") -> str:
         """ Method for writing a module to a string

--- a/mpactpy/module.py
+++ b/mpactpy/module.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+from typing import Dict, List, Any
+from math import isclose
+
+from mpactpy.material import Material
+from mpactpy.pinmesh import PinMesh
+from mpactpy.pin import Pin
+from mpactpy.utils import list_to_str, unique, is_rectangular
+
+
+class Module():
+    """  Module of an MPACT model
+
+    Attributes
+    ----------
+    mpact_id : int
+        The MPACT ID of the module
+    nx : int
+        Number of pins along the x-dimension
+    ny : int
+        Number of pins along the y-dimension
+    nz : int
+        Number of pins along the z-dimension
+    pitch : Dict[str, float]
+        The pitch of the module in each axis direction (keys: 'X', 'Y', 'Z') (cm)
+    pin_map : List[List[Pin]]
+        The 2-D array of pin.  This array is extruded
+        nz times in the z-direction
+    pins : List[Pin]
+        The unique pins of this module
+    pinmeshes : List[PinMesh]
+        The unique pin meshes of this module
+    materials : List[Material]
+        The materials of this module
+    """
+
+    @property
+    def mpact_id(self) -> int:
+        return self._mpact_id
+
+    @mpact_id.setter
+    def mpact_id(self, mpact_id: int) -> None:
+        assert(mpact_id > 0), f"mpact_id = {mpact_id}"
+        self._mpact_id = mpact_id
+
+    @property
+    def nx(self) -> int:
+        return len(self.pin_map)
+
+    @property
+    def ny(self) -> int:
+        return  len(self.pin_map[0])
+
+    @property
+    def nz(self) -> int:
+        return self._nz
+
+    @property
+    def pitch(self) -> Dict[str, float]:
+        return self._pitch
+
+    @property
+    def pin_map(self) -> List[List[Pin]]:
+        return self._pin_map
+
+    @property
+    def pins(self) -> List[Pin]:
+        return self._pins
+
+    @property
+    def pinmeshes(self) -> List[PinMesh]:
+        return self._pinmeshes
+
+    @property
+    def materials(self) -> List[Material]:
+        return self._materials
+
+    def __init__(self, nz: int, pin_map: List[List[Pin]], mpact_id: int = 1):
+
+        assert nz > 0
+        assert is_rectangular(pin_map)
+
+        self.mpact_id = mpact_id
+        self._nz      = nz
+        self._pin_map = pin_map
+        self.set_unique_elements()
+
+        assert all(isclose(self.pin_map[i][j].pitch['X'], self.pin_map[0][j].pitch['X'])
+                   for j in range(self.ny) for i in range(self.nx))
+
+        assert all(isclose(self.pin_map[i][j].pitch['Y'], self.pin_map[i][0].pitch['Y'])
+                   for i in range(self.nx) for j in range(self.ny))
+
+        assert all(isclose(pin.pitch['Z'], self.pins[0].pitch['Z']) for pin in self.pins)
+
+        x_pitch     = sum(self.pin_map[0][j].pitch['X'] for j in range(self.ny))
+        y_pitch     = sum(self.pin_map[i][0].pitch['Y'] for i in range(self.nx))
+        z_pitch     = self.pins[0].pitch['Z'] * self.nz
+        self._pitch = {'X': x_pitch, 'Y': y_pitch, 'Z': z_pitch}
+
+
+    def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
+        return (isinstance(other, Module)     and
+                self.nz      == other.nz      and
+                self.pin_map == other.pin_map
+               )
+
+    def __hash__(self) -> int:
+        return hash((self.nz,
+                     tuple([tuple(row) for row in self.pin_map])))
+
+    def write_to_string(self, prefix: str = "") -> str:
+        """ Method for writing a module to a string
+
+        Parameter
+        ---------
+        prefix : str
+            A prefix with which to start each line of the written output string
+
+        Returns
+        -------
+        str
+            The string that represents the module
+        """
+
+        id_length = max(len(str(pin.mpact_id)) for row in self.pin_map for pin in row)
+
+        string = prefix + f"module {self.mpact_id} {self.nx} {self.ny} {self.nz}\n"
+        for row in self.pin_map:
+            pins = [pin.mpact_id for pin in row]
+            string += prefix + prefix + f"{list_to_str(pins, id_length)}\n"
+        return string
+
+
+    def set_unique_elements(self, other_pins: List[Pin]  = []) -> None:
+        """ Determines and sets the unique elements of the module
+
+        Parameters
+        ----------
+        other_pins : List[Pin]
+            The pins from other modules which should be considered as already defined
+        """
+        # NOTE: To get the ordering correct, other_pins must by left-hand-side added to the map list
+        already_defined_pins      = unique(other_pins + [pin for row in self.pin_map for pin in row])
+        already_defined_pinmeshes = unique([pin.pinmesh for pin in already_defined_pins])
+        already_defined_materials = unique([material for pin in already_defined_pins for material in pin.materials])
+
+        for i, _ in enumerate(self.pin_map):
+            for j, _ in enumerate(self.pin_map[i]):
+                self.pin_map[i][j].set_unique_elements(already_defined_pinmeshes, already_defined_materials)
+                self._pin_map[i][j] = next(pin for pin in already_defined_pins if self.pin_map[i][j] == pin)
+
+        self._pins      = unique([pin for row in self.pin_map for pin in row])
+        self._pinmeshes = unique([pin.pinmesh for pin in self.pins])
+        self._materials = unique([material for pin in self.pins for material in pin.materials])
+
+
+    def get_axial_slice(self, start_pos: float, stop_pos: float) -> Module:
+        """ Method for creating a new Module from an axial slice of this Module
+
+        Parameters
+        ----------
+        start_pos : float
+            The starting axial position of the slice
+        stop_pos : float
+            The stopping axial position of the slice
+
+        Returns
+        -------
+        Module
+            The new Module created from the axial slice
+        """
+
+        assert stop_pos > start_pos
+
+        if stop_pos  <= 0.              or isclose(stop_pos,  0.) or \
+           start_pos >= self.pitch["Z"] or isclose(start_pos, self.pitch["Z"]):
+            return None
+
+        start_pos = max(0,               start_pos)
+        stop_pos  = min(self.pitch["Z"], stop_pos)
+
+        pin_map = []
+        for row in self.pin_map:
+            pin_map.append([])
+            for pin in row:
+                stack = None
+                for z in range(self.nz):
+                    z0 = z * pin.pitch["Z"]
+                    pin_slice = pin.get_axial_slice(start_pos-z0, stop_pos-z0)
+                    if pin_slice:
+                        stack = stack.axial_merge(pin_slice) if stack else pin_slice
+                pin_map[-1].append(stack)
+
+        return Module(1, pin_map)

--- a/mpactpy/pin.py
+++ b/mpactpy/pin.py
@@ -248,14 +248,16 @@ def build_gcyl_pin(bounds:                  Tuple[float, float, float, float],
         The constructed Pin
     """
 
-    xmin = bounds[0]; xmax = bounds[1]
-    ymin = bounds[2]; ymax = bounds[3]
+    xmin = bounds[0]
+    xmax = bounds[1]
+    ymin = bounds[2]
+    ymax = bounds[3]
 
     for dim in ["R", "S", "Z"]:
         target_cell_thicknesses.setdefault(dim, inf)
 
-    assert(xmin < xmax)
-    assert(ymin < ymax)
+    assert xmin < xmax
+    assert ymin < ymax
     assert all(thickness > 0. for axis in thicknesses.values() for thickness in axis)
     assert all(thickness > 0. for thickness in target_cell_thicknesses.values())
     assert len(materials) == (len(thicknesses['R']) + 1) * len(thicknesses['Z'])
@@ -270,7 +272,8 @@ def build_gcyl_pin(bounds:                  Tuple[float, float, float, float],
     r     = list(accumulate(r_subds))
     ndivr = [1] * len(r) # Subdivision was already performed by the target_cell_thickness
 
-    num_a_subd = max(1, (int(2.*pi*r[-1] // target_cell_thicknesses["S"]) + 3) // 4 * 4) # Special arithmetic here ensures azimuthal subdivisions are divisible by 4
+    # Special arithmetic here ensures azimuthal subdivisions are divisible by 4
+    num_a_subd = max(1, (int(2.*pi*r[-1] // target_cell_thicknesses["S"]) + 3) // 4 * 4)
     ndiva      = [num_a_subd] * len(r) + [num_a_subd]
 
     ndivz = [max(1, int(thickness // target_cell_thicknesses["Z"])) for thickness in thicknesses["Z"]]

--- a/mpactpy/pin.py
+++ b/mpactpy/pin.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
-from typing import Dict, List, Any, Union, TypedDict
-from math import isclose
+from typing import Dict, List, Any, Union, TypedDict, Tuple
+from math import isclose, inf, pi
 from copy import deepcopy
+from itertools import accumulate
 
 from mpactpy.material import Material
-from mpactpy.pinmesh import PinMesh
+from mpactpy.pinmesh import PinMesh, RectangularPinMesh, GeneralCylindricalPinMesh
 from mpactpy.utils import list_to_str, unique
 
 
@@ -170,3 +171,119 @@ class Pin():
 
         materials = self.materials + pin.materials
         return Pin(pinmesh_template, materials)
+
+
+def build_rec_pin(thicknesses:             Dict[str, List[float]],
+                  materials:               List[Material],
+                  target_cell_thicknesses: Dict[str, float] = {}) -> Pin:
+    """ Factory for building Rectangular Mesh Pins
+
+    This factory, unlike construction via the "normal means" using
+    RectangularPinMesh, allows users to specify a target material region thickness
+    for each of the 3 axes.  This will make the subdivisions for each material region
+    such that cell thickness will not exceed the target cell thicknesses.
+
+    Parameters
+    ----------
+    thicknesses : Dict[str, List[float]]
+        The thicknesses of each material region division in each axis-direction
+        (keys: "X", "Y", "Z")
+    materials : List[Material]
+        The list of materials ordered from top-to-bottom and left-to-right for the material divisions
+    target_cell_thicknesses : Dict[str, float]
+        The target side length of the cells (cm).  Defaults to infinity for dimensions where no targets provided.
+        (keys: "X", "Y", "Z")
+
+    Returns
+    -------
+    Pin
+        The constructed Pin
+    """
+
+    for dim in ["X", "Y", "Z"]:
+        target_cell_thicknesses.setdefault(dim, inf)
+
+    assert all(thickness > 0. for axis in thicknesses.values() for thickness in axis)
+    assert all(thickness > 0. for thickness in target_cell_thicknesses.values())
+    assert len(materials) == len(thicknesses["X"]) * len(thicknesses["Y"]) * len(thicknesses["Z"])
+    ndiv = {axis: [max(1, int(thickness // target_cell_thicknesses[axis]))
+                   for thickness in thicknesses[axis]] for axis in ["X", "Y", "Z"]}
+    vals = {axis: list(accumulate(thicknesses[axis])) for axis in ["X", "Y", "Z"]}
+    mesh  = RectangularPinMesh(vals["X"], vals["Y"], vals["Z"], ndiv["X"], ndiv["Y"], ndiv["Z"])
+    return Pin(mesh, materials)
+
+
+
+def build_gcyl_pin(bounds:                  Tuple[float, float, float, float],
+                   thicknesses:             Dict[str, List[float]],
+                   materials:               List[Material],
+                   target_cell_thicknesses: Dict[str, float] = {}) -> Pin:
+    """ Factory for building General Cylindrical Mesh Pins
+
+    This factory, unlike construction via the "normal means" using
+    GeneralCylindricalPinMesh, allows users to specify a target material region thickness
+    for R, Arc-Length, and Z.  This will make the subdivisions for each material region
+    such that cell thickness will not exceed the target cell thicknesses. For Arc-length,
+    the outer most radius is considered when determining how much to subdivide,
+    with the resultant number of azimuthal subdivisions being applied to all material regions.
+    Also with arc-length, the number of subdivisions is rounded up to the nearest number divisible by 4
+    since in most practical use cases, the number of azimuthal devisions should be evenly split over pin quadrants.
+
+    Parameters
+    ----------
+    bounds: Tuple[float, float, float, float]
+        The bounds of the GCYL pincell (order: x_min, x_max, y_min, y_max)
+    thicknesses : Dict[str, List[float]]
+        The thicknesses of each material region division in each axis-direction
+        (keys: "R", "Z")
+    materials : List[Material]
+        The list of materials ordered from top-to-bottom and left-to-right for the material divisions
+    target_cell_thicknesses : Dict[str, float]
+        The target side length of the cells (cm). Defaults to infinity for dimensions where no targets provided.
+        (keys: "R", "S", "Z")
+
+    Returns
+    -------
+    Pin
+        The constructed Pin
+    """
+
+    xmin = bounds[0]; xmax = bounds[1]
+    ymin = bounds[2]; ymax = bounds[3]
+
+    for dim in ["R", "S", "Z"]:
+        target_cell_thicknesses.setdefault(dim, inf)
+
+    assert(xmin < xmax)
+    assert(ymin < ymax)
+    assert all(thickness > 0. for axis in thicknesses.values() for thickness in axis)
+    assert all(thickness > 0. for thickness in target_cell_thicknesses.values())
+    assert len(materials) == (len(thicknesses['R']) + 1) * len(thicknesses['Z'])
+
+    r_subds     = []
+    num_r_subds = []
+    for thickness in thicknesses["R"]:
+        num_subd = max(1, int(thickness // target_cell_thicknesses["R"]))
+        r_subds.extend([thickness / num_subd] * num_subd)
+        num_r_subds.append(num_subd)
+
+    r     = list(accumulate(r_subds))
+    ndivr = [1] * len(r) # Subdivision was already performed by the target_cell_thickness
+
+    num_a_subd = max(1, (int(2.*pi*r[-1] // target_cell_thicknesses["S"]) + 3) // 4 * 4) # Special arithmetic here ensures azimuthal subdivisions are divisible by 4
+    ndiva      = [num_a_subd] * len(r) + [num_a_subd]
+
+    ndivz = [max(1, int(thickness // target_cell_thicknesses["Z"])) for thickness in thicknesses["Z"]]
+    zvals = list(accumulate(thicknesses["Z"]))
+
+    subdivided_materials = []
+    m = 0
+    for _ in zvals:
+        for num_subd in num_r_subds:
+            subdivided_materials.extend([materials[m]] * num_subd)
+            m += 1
+        subdivided_materials.append(materials[m])
+        m += 1
+
+    mesh = GeneralCylindricalPinMesh(r, xmin, xmax, ymin, ymax, zvals, ndivr, ndiva, ndivz)
+    return Pin(mesh, subdivided_materials)

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Dict, List, Any
+from math import isclose, hypot
+
+from mpactpy.utils import relative_round, allclose, list_to_str, ROUNDING_RELATIVE_TOLERANCE as TOL
+
+
+class PinMesh(ABC):
+    """  An abstract class for MPACT model pinmeshes
+
+    A subtle nuance of MPACT that must be addressed regarding pinmeshes is the
+    handling of material / cross-section regions (XSRs) that don't lie at least
+    partially within the boundaries of a given pinmesh.  Currently, MPACT requires
+    the user to NOT specify XSRs (and their materials in the Pin Cards) which don't lie at least
+    partially within the bounds of the mesh.  However, having the client keep track
+    of which XSRs are and are not partially within the bounds can be very tedious for
+    the client.  Therefore, this API will provide helper methods to make this current nuance
+    of MPACT transparent to the client.  Meaning, the client need not to concern themselves
+    whether their XSR definitions and materials exist within the mesh bounds or not.
+
+    Attributes
+    ----------
+    id : int
+        The ID of the pinmesh
+    number_of_material_regions : int
+        The total number of pinmesh material regions (i.e. cross-section regions) regardless
+        of whether they fall within the bounds of the pinmesh or not
+    zvals : List[float]
+        The z-coordinates marking material interfaces within the pin
+    ndivz : List[int]
+        The number of equally spaced flat source regions to use when
+        dividing the grid defined by zval
+    pitch : Dict[str, float]
+        The pitch of the pin mesh in each axis direction (keys: 'X', 'Y', 'Z')
+    regions_inside_bounds = List[int]
+        The list of material regions that lie within the bounds of the pinmesh
+    """
+
+    @property
+    def id(self) -> int:
+        return self._id
+
+    @id.setter
+    def id(self, id: int) -> None:
+        assert(id > 0), f"id = {id}"
+        self._id = id
+
+    @property
+    def number_of_material_regions(self) -> int:
+        return self._number_of_material_regions
+
+    @property
+    def zvals(self) -> List[float]:
+        return self._zvals
+
+    @property
+    def ndivz(self) -> List[int]:
+        return self._ndivz
+
+    @property
+    def pitch(self) -> Dict[str, float]:
+        return self._pitch
+
+    @property
+    def regions_inside_bounds(self) -> List[int]:
+        return self._regions_inside_bounds
+
+    @abstractmethod
+    def write_to_string(self, prefix: str = "") -> str:
+        """ Method for writing pin mesh to a string
+
+        Parameter
+        ---------
+        prefix : str
+            A prefix with which to start each line of the written output string
+
+        Returns
+        -------
+        str
+            The string that represents the pin mesh
+        """
+        pass
+
+    def _set_axial_mesh(self, zvals: List[float] = None, ndivz: List[int] = None) -> None:
+        """ A method for setting the axial meshing of a pinmesh
+
+        Parameters
+        ----------
+        zvals : List[float]
+            The z-coordinates marking material interfaces within the pin
+        ndivz : List[int]
+            The number of equally spaced flat source regions to use when
+            dividing the grid defined by zval
+        """
+        assert len(zvals) > 0, f"len(zvals) = {len(zvals)}"
+        assert all(val > 0. for val in zvals), f"zvals = {zvals}"
+        assert all(zvals[i-1] < zvals[i] for i in range(1,len(zvals))), f"zvals = {zvals}"
+        assert (len(ndivz) == len(zvals)), f"len(ndivz) = {len(ndivz)}, len(zvals) = {len(zvals)}"
+        assert all(val > 0 for val in ndivz), f""
+
+        self._zvals = zvals
+        self._ndivz = ndivz
+
+
+    @abstractmethod
+    def _set_pitch(self) -> None:
+        """ Method for setting the pinmesh pitches
+        """
+        pass
+
+    @abstractmethod
+    def _set_number_of_material_regions(self) -> None:
+        """ Method for setting the pinmesh number of material regions
+        """
+        pass
+
+    @abstractmethod
+    def _set_regions_inside_bounds(self) -> None:
+        """ Method for setting the material regions that are inside the pinmesh bounds
+        """
+        pass
+
+class RectangularPinMesh(PinMesh):
+    """  An MPACT model pin mesh made up of a 3-D rectilinear grid
+
+    Attributes
+    ----------
+    xvals : List[float]
+        The x-coordinates marking material interfaces within the pin
+    yvals : List[float]
+        The y-coordinates marking material interfaces within the pin
+    ndivx : List[int]
+        The number of equally spaced flat source regions to use when
+        dividing the grid defined by xval
+    ndivy : List[int]
+        The number of equally spaced flat source regions to use when
+        dividing the grid defined by yval
+    """
+
+    @property
+    def xvals(self) -> List[float]:
+        return self._xvals
+
+    @property
+    def yvals(self) -> List[float]:
+        return self._yvals
+
+    @property
+    def ndivx(self) -> List[int]:
+        return self._ndivx
+
+    @property
+    def ndivy(self) -> List[int]:
+        return self._ndivy
+
+
+    def __init__(self,
+                 xvals: List[float],
+                 yvals: List[float],
+                 zvals: List[float],
+                 ndivx: List[int],
+                 ndivy: List[int],
+                 ndivz: List[int],
+                 id: int = 1
+    ):
+        assert len(xvals) > 0, f"len(xvals) = {len(xvals)}"
+        assert len(yvals) > 0, f"len(yvals) = {len(yvals)}"
+        assert all(val > 0. for val in xvals), f"xvals = {xvals}"
+        assert all(val > 0. for val in yvals), f"yvals = {yvals}"
+        assert all(val > 0. for val in zvals), f"zvals = {zvals}"
+        assert all(xvals[i-1] < xvals[i] for i in range(1,len(xvals))), f"xvals = {xvals}"
+        assert all(yvals[i-1] < yvals[i] for i in range(1,len(yvals))), f"yvals = {yvals}"
+        assert (len(ndivx) == len(xvals)), f"len(ndivx) = {len(ndivx)}, len(xvals) = {len(xvals)}"
+        assert (len(ndivy) == len(yvals)), f"len(ndivy) = {len(ndivy)}, len(yvals) = {len(yvals)}"
+        assert all(val > 0 for val in ndivx), f"ndivx = {ndivx}"
+        assert all(val > 0 for val in ndivy), f"ndivy = {ndivy}"
+
+        self.id     = id
+        self._xvals = xvals
+        self._yvals = yvals
+        self._ndivx = ndivx
+        self._ndivy = ndivy
+
+        self._set_axial_mesh(zvals, ndivz)
+        self._set_pitch()
+        self._set_number_of_material_regions()
+        self._set_regions_inside_bounds()
+
+
+    def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
+        return (isinstance(other, RectangularPinMesh)           and
+                allclose(self.xvals, other.xvals, rtol=TOL)     and
+                allclose(self.yvals, other.yvals, rtol=TOL)     and
+                allclose(self.zvals, other.zvals, rtol=TOL)     and
+                allclose(self.ndivx, other.ndivx, rtol=TOL)     and
+                allclose(self.ndivy, other.ndivy, rtol=TOL)     and
+                allclose(self.ndivz, other.ndivz, rtol=TOL)
+               )
+
+
+    def __hash__(self) -> int:
+        pitches = {key : relative_round(val, TOL) for key, val in self.pitch.items()}
+        return hash((tuple([relative_round(val, TOL) for val in self.xvals]),
+                     tuple([relative_round(val, TOL) for val in self.yvals]),
+                     tuple([relative_round(val, TOL) for val in self.zvals]),
+                     tuple([relative_round(val, TOL) for val in self.ndivx]),
+                     tuple([relative_round(val, TOL) for val in self.ndivy]),
+                     tuple([relative_round(val, TOL) for val in self.ndivz]),
+                     tuple(sorted(pitches)),
+                     self.number_of_material_regions))
+
+    def write_to_string(self, prefix: str = "") -> str:
+
+        string =  prefix
+        string += f"pinmesh {self.id} rec {list_to_str(self._xvals)} / {list_to_str(self._yvals)} / {list_to_str(self._zvals)} / "
+        string +=                  f"{list_to_str(self._ndivx)} / {list_to_str(self._ndivy)} / {list_to_str(self._ndivz)}\n"
+
+        return string
+
+    def _set_pitch(self) -> None:
+        self._pitch = {'X' : self.xvals[-1], 'Y' : self.yvals[-1], 'Z' : self.zvals[-1]}
+
+    def _set_number_of_material_regions(self) -> None:
+        self._number_of_material_regions = len(self.xvals)*len(self.yvals)*len(self.zvals)
+
+    def _set_regions_inside_bounds(self) -> None:
+        self._regions_inside_bounds = len(self.xvals)*len(self.yvals)*len(self.zvals)
+
+
+class GeneralCylindricalPinMesh(PinMesh):
+    """  An MPACT model pin mesh made up of a concentric cylinders centered at (0,0) with arbitrary pin boundaries
+
+    Attributes
+    ----------
+    r : List[float]
+        Array of radii for indicating the different material interfaces
+    xMin : float
+        Pin boundary x-min
+    xMax : float
+        Pin boundary x-max
+    yMin : float
+        Pin boundary y-min
+    yMax : float
+        Pin boundary y-max
+    ndivr : List[int]
+        The number of equal-volume rings to use when dividing the concentric cylinders
+        into flat source regions
+    ndiva : List[int]
+        The number of equal-angle ”pie-slices” to use when dividing each concentric ring
+        into flat source regions azimuthally
+    """
+
+    @property
+    def r(self) -> List[float]:
+        return self._r
+
+    @property
+    def xMin(self) -> float:
+        return self._xMin
+
+    @property
+    def xMax(self) -> float:
+        return self._xMax
+
+    @property
+    def yMin(self) -> float:
+        return self._yMin
+
+    @property
+    def yMax(self) -> float:
+        return self._yMax
+
+    @property
+    def ndivr(self) -> List[int]:
+        return self._ndivr
+
+    @property
+    def ndiva(self) -> List[int]:
+        return self._ndiva
+
+
+    def __init__(self,
+        r     : List[float],
+        xMin  : float,
+        xMax  : float,
+        yMin  : float,
+        yMax  : float,
+        zvals : List[float],
+        ndivr : List[int],
+        ndiva : List[int],
+        ndivz : List[int],
+        id: int = 1
+    ):
+        assert len(r) > 0, f"len(r) = {len(r)}"
+        assert all(val > 0. for val in r), f"r = {r}"
+        assert xMin < xMax, f"xMin = {xMin}, xMax = {xMax}"
+        assert yMin < yMax, f"yMin = {yMin}, yMax = {yMax}"
+        assert len(ndivr) == len(r), f"len(ndivr) = {len(ndivr)}, len(r) = {len(r)}"
+        assert len(ndiva) == sum(ndivr)+1, f"len(ndiva) = {len(ndiva)}, sum(ndivr)+1 = {sum(ndivr)+1}"
+        assert all(val > 0 for val in ndivr), f"ndivr = {ndivr}"
+        assert all(val > 0 for val in ndiva), f"ndiva = {ndiva}"
+
+        self.id     = id
+        self._r     = r
+        self._xMin  = xMin
+        self._xMax  = xMax
+        self._yMin  = yMin
+        self._yMax  = yMax
+        self._ndivr = ndivr
+        self._ndiva = ndiva
+
+        self._set_axial_mesh(zvals, ndivz)
+        self._set_pitch()
+        self._set_number_of_material_regions()
+        self._set_regions_inside_bounds()
+
+
+    def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
+        return (isinstance(other, GeneralCylindricalPinMesh)   and
+                allclose(self.r,     other.r,     rtol=TOL)    and
+                isclose( self.xMin,  other.xMin,  rel_tol=TOL) and
+                isclose( self.xMax,  other.xMax,  rel_tol=TOL) and
+                isclose( self.yMin,  other.yMin,  rel_tol=TOL) and
+                isclose( self.yMax,  other.yMax,  rel_tol=TOL) and
+                allclose(self.zvals, other.zvals, rtol=TOL)    and
+                allclose(self.ndivr, other.ndivr, rtol=TOL)    and
+                allclose(self.ndiva, other.ndiva, rtol=TOL)    and
+                allclose(self.ndivz, other.ndivz, rtol=TOL)
+               )
+
+
+    def __hash__(self) -> int:
+        pitches = {key : relative_round(val, TOL) for key, val in self.pitch.items()}
+        return hash((relative_round(self.xMin, TOL),
+                     relative_round(self.xMax, TOL),
+                     relative_round(self.yMin, TOL),
+                     relative_round(self.yMax, TOL),
+                     tuple([relative_round(val, TOL) for val in self.r]),
+                     tuple([relative_round(val, TOL) for val in self.zvals]),
+                     tuple([relative_round(val, TOL) for val in self.ndivr]),
+                     tuple([relative_round(val, TOL) for val in self.ndiva]),
+                     tuple([relative_round(val, TOL) for val in self.ndivz]),
+                     tuple(sorted(pitches)),
+                     self.number_of_material_regions))
+
+    def write_to_string(self, prefix: str = "") -> str:
+
+        string = prefix
+        string += f"pinmesh {self.id} gcyl {list_to_str(self._r_inside_bounds)} / {self._xMin} {self._xMax} {self._yMin} {self._yMax} / "
+        string += f"{list_to_str(self._zvals)} / {list_to_str(self._ndivr_inside_bounds)} / {list_to_str(self._ndiva_inside_bounds)} / {list_to_str(self._ndivz)}\n"
+
+        return string
+
+    def _set_pitch(self) -> None:
+        self._pitch = {'X' : self.xMax - self.xMin,
+                       'Y' : self.yMax - self.yMin,
+                       'Z' : self.zvals[-1]}
+
+    def _set_number_of_material_regions(self) -> None:
+        self._number_of_material_regions = (len(self.r)+1)*len(self.zvals)
+
+
+    def _set_regions_inside_bounds(self) -> None:
+
+        corners = [hypot(self.xMin, self.yMin), hypot(self.xMin, self.yMax), hypot(self.xMax, self.yMin), hypot(self.xMax, self.yMax)]
+
+        def circle_encloses_box(r):
+            return all(corner < r for corner in corners)
+
+        def box_encloses_circle(r):
+            return ((self.xMin < -r or isclose(self.xMin, -r)) and (r < self.xMax or isclose(self.xMax, r)) and
+                    (self.yMin < -r or isclose(self.yMin, -r)) and (r < self.yMax or isclose(self.yMax, r)))
+
+        def box_overlaps_circle(r):
+            return not all(r < corner or isclose(r, corner) for corner in corners) or box_encloses_circle(r)
+
+        radii_inside_bounds = [i for i,r in enumerate(self.r)
+                               if box_overlaps_circle(r) and not circle_encloses_box(r)]
+
+        assert radii_inside_bounds, f"No radii found within bounds of PinMesh: {self.id}"
+
+        self._r_inside_bounds       = [self._r[i] for i in radii_inside_bounds]
+        self._ndivr_inside_bounds   = [self._ndivr[i] for i in radii_inside_bounds]
+
+        self._ndiva_inside_bounds   = []
+        j = 0
+        for i, ndivr in enumerate(self.ndivr):
+            if i in radii_inside_bounds:
+                self._ndiva_inside_bounds.extend(self.ndiva[j:j+ndivr])
+            elif i > radii_inside_bounds[-1]:
+                break
+            j += ndivr
+
+        self._ndiva_inside_bounds.extend(self.ndiva[j:j+1])
+
+
+        self._regions_inside_bounds = [
+            i + z * (len(self.r) + 1)
+            for z in range(len(self.zvals))
+            for i in radii_inside_bounds + [radii_inside_bounds[-1] + 1]
+        ]

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -377,8 +377,9 @@ class GeneralCylindricalPinMesh(PinMesh):
         radii_inside_bounds = [i for i,r in enumerate(self.r)
                                if box_overlaps_circle(r) and not circle_encloses_box(r)]
 
-        assert radii_inside_bounds, f"GCYL PinMesh with bounds {self.xMin, self.yMin, self.xMax, self.yMax} "+ \
-                                     "has no cylinder regions which fall within the bounds"
+        assert radii_inside_bounds or circle_encloses_box(self.r[0]), \
+            f"GCYL PinMesh with bounds {self.xMin, self.yMin, self.xMax, self.yMax} "+ \
+             "has no cylinder regions which fall within the bounds"
 
         self._r_inside_bounds       = [self._r[i] for i in radii_inside_bounds]
         self._ndivr_inside_bounds   = [self._ndivr[i] for i in radii_inside_bounds]

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -87,7 +87,7 @@ class PinMesh(ABC):
             The string that represents the pin mesh
         """
 
-    def _set_axial_mesh(self, zvals: List[float] = None, ndivz: List[int] = None) -> None:
+    def set_axial_mesh(self, zvals: List[float] = None, ndivz: List[int] = None) -> None:
         """ A method for setting the axial meshing of a pinmesh
 
         Parameters
@@ -106,6 +106,10 @@ class PinMesh(ABC):
 
         self._zvals = zvals
         self._ndivz = ndivz
+
+        self._set_pitch()
+        self._set_number_of_material_regions()
+        self._set_regions_inside_bounds()
 
 
     @abstractmethod
@@ -185,10 +189,7 @@ class RectangularPinMesh(PinMesh):
         self._ndivx   = ndivx
         self._ndivy   = ndivy
 
-        self._set_axial_mesh(zvals, ndivz)
-        self._set_pitch()
-        self._set_number_of_material_regions()
-        self._set_regions_inside_bounds()
+        self.set_axial_mesh(zvals, ndivz)
 
 
     def __eq__(self, other: Any) -> bool:
@@ -256,6 +257,9 @@ class GeneralCylindricalPinMesh(PinMesh):
         The number of equal-angle ”pie-slices” to use when dividing each concentric ring
         into flat source regions azimuthally
     """
+    _r_inside_bounds: List[float]
+    _ndivr_inside_bounds: List[int]
+    _ndiva_inside_bounds: List[int]
 
     @property
     def r(self) -> List[float]:
@@ -316,10 +320,7 @@ class GeneralCylindricalPinMesh(PinMesh):
         self._ndivr   = ndivr
         self._ndiva   = ndiva
 
-        self._set_axial_mesh(zvals, ndivz)
-        self._set_pitch()
-        self._set_number_of_material_regions()
-        self._set_regions_inside_bounds()
+        self.set_axial_mesh(zvals, ndivz)
 
 
     def __eq__(self, other: Any) -> bool:

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -232,7 +232,7 @@ class RectangularPinMesh(PinMesh):
         self._number_of_material_regions = len(self.xvals)*len(self.yvals)*len(self.zvals)
 
     def _set_regions_inside_bounds(self) -> None:
-        self._regions_inside_bounds = len(self.xvals)*len(self.yvals)*len(self.zvals)
+        self._regions_inside_bounds = list(range(len(self.xvals)*len(self.yvals)*len(self.zvals)))
 
 
 class GeneralCylindricalPinMesh(PinMesh):

--- a/mpactpy/utils.py
+++ b/mpactpy/utils.py
@@ -66,8 +66,9 @@ def allclose(rhs:  List[Union[float, int]],
         True if lists are element-wise approximately equal, False otherwise
     """
 
-    if len(rhs) != len(lhs): return False
-    return np.allclose(rhs, lhs)
+    if len(rhs) != len(lhs):
+        return False
+    return np.allclose(rhs, lhs, rtol, atol)
 
 
 def list_to_str(input_list: List[Union[float, int]], print_length: int = None) -> str:
@@ -90,8 +91,7 @@ def list_to_str(input_list: List[Union[float, int]], print_length: int = None) -
         if isinstance(num, float):
             if math.isclose(num, round(num)):
                 return f"{num:.1f}" if print_length is None else f"{num:{print_length}.1f}"
-            else:
-                return f"{num:.15g}" if print_length is None else f"{num:{print_length}.15g}"
+            return f"{num:.15g}" if print_length is None else f"{num:{print_length}.15g}"
         return f"{str(num)}" if print_length is None else f"{str(num):{print_length}}"
 
     return ' '.join(print_num(x, print_length) for x in input_list)

--- a/mpactpy/utils.py
+++ b/mpactpy/utils.py
@@ -33,7 +33,7 @@ def relative_round(value: float, rel_tol: float =1e-9) -> float:
     if value == 0:
         return 0.0
 
-    abs_tol       = rel_tol * max(abs(value), 1.0)
+    abs_tol       = rel_tol * abs(value)
     decimals      = max(0, int(math.ceil(-math.log10(abs_tol))))
     quantization  = Decimal(f'1e-{decimals}')
     rounded_value = Decimal(value).quantize(quantization, rounding=ROUND_HALF_UP)

--- a/mpactpy/utils.py
+++ b/mpactpy/utils.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Union, Hashable, TypeVar
 from decimal import Decimal, ROUND_HALF_UP
 import math
 
@@ -95,3 +95,19 @@ def list_to_str(input_list: List[Union[float, int]], print_length: int = None) -
         return f"{str(num)}" if print_length is None else f"{str(num):{print_length}}"
 
     return ' '.join(print_num(x, print_length) for x in input_list)
+
+T = TypeVar('T', bound=Hashable)
+def unique(elements: List[T]) -> List[T]:
+    """ Function for extracting the unique elements of a list while preserving the original order of the elements
+
+    Parameters
+    ----------
+    elements : List[T]
+        The list of elements from which the unique elements will be identified
+
+    Returns
+    -------
+    List[T]
+        The list of unique elements
+    """
+    return list(dict.fromkeys(elements))

--- a/mpactpy/utils.py
+++ b/mpactpy/utils.py
@@ -1,9 +1,14 @@
+from typing import List, Union
 from decimal import Decimal, ROUND_HALF_UP
 import math
 
+import numpy as np
+
+# The relative tolerance for rounding floating point numbers
+ROUNDING_RELATIVE_TOLERANCE = 1E-5
+
 def relative_round(value: float, rel_tol: float =1e-9) -> float:
-    """
-    Rounds a floating-point number to a precision consistent with a given relative tolerance.
+    """ Rounds a floating-point number to a precision consistent with a given relative tolerance.
 
     Parameters:
     -----------
@@ -33,3 +38,60 @@ def relative_round(value: float, rel_tol: float =1e-9) -> float:
     quantization  = Decimal(f'1e-{decimals}')
     rounded_value = Decimal(value).quantize(quantization, rounding=ROUND_HALF_UP)
     return float(rounded_value)
+
+
+def allclose(rhs:  List[Union[float, int]],
+             lhs:  List[Union[float, int]],
+             rtol: float = 1E-05,
+             atol: float = 1E-08) -> bool:
+    """ Checks to see if the lists are approximately equal
+
+    We need this helper function because np.allclose does not
+    gracefully handle lists with different sizes.
+
+    Parameters
+    ----------
+    rhs : List[Union[float, int]]
+        The right-hand-side list to be compared
+    lhs : List[Union[float, int]]
+        The left-hand-side list to be compared
+    rtol : float
+        The relative tolerance for the comparison
+    atol : float
+        The absolute tolerance for the comparison
+
+    Returns
+    -------
+    bool
+        True if lists are element-wise approximately equal, False otherwise
+    """
+
+    if len(rhs) != len(lhs): return False
+    return np.allclose(rhs, lhs)
+
+
+def list_to_str(input_list: List[Union[float, int]], print_length: int = None) -> str:
+    """ Converts a list of numerical values to an equally spaced string
+
+    Parameters
+    ----------
+    input_list : List[Union[float, int]]
+        The list to be converted to a string
+    print_length : int
+        The print spacing for the string
+
+    Returns
+    -------
+    str
+        The list as a string
+    """
+
+    def print_num(num: Union[float, int], print_length: int) -> str:
+        if isinstance(num, float):
+            if math.isclose(num, round(num)):
+                return f"{num:.1f}" if print_length is None else f"{num:{print_length}.1f}"
+            else:
+                return f"{num:.15g}" if print_length is None else f"{num:{print_length}.15g}"
+        return f"{str(num)}" if print_length is None else f"{str(num):{print_length}}"
+
+    return ' '.join(print_num(x, print_length) for x in input_list)

--- a/mpactpy/utils.py
+++ b/mpactpy/utils.py
@@ -114,12 +114,12 @@ def unique(elements: List[T]) -> List[T]:
     return list(dict.fromkeys(elements))
 
 
-def is_rectangular(map: List[List[T]]) -> bool:
+def is_rectangular(map_2D: List[List[T]]) -> bool:
     """ A helper function for checking whether or not a 2D map of elements is rectangular or not
 
     Parameters
     ----------
-    map : List[List[T]]
+    map_2D : List[List[T]]
         The 2D Map to be checked
 
     Returns
@@ -127,7 +127,4 @@ def is_rectangular(map: List[List[T]]) -> bool:
     True if the 2D Map is rectangular, False otherwise
     """
 
-    if len(map)    == 0:                                           return False
-    if len(map[0]) == 0:                                           return False
-    if any([len(map[i]) != len(map[0]) for i in range(len(map))]): return False
-    return True
+    return bool(map_2D and map_2D[0]) and all(len(row) == len(map_2D[0]) for row in map_2D)

--- a/mpactpy/utils.py
+++ b/mpactpy/utils.py
@@ -97,6 +97,7 @@ def list_to_str(input_list: List[Union[float, int]], print_length: int = None) -
     return ' '.join(print_num(x, print_length) for x in input_list)
 
 T = TypeVar('T', bound=Hashable)
+
 def unique(elements: List[T]) -> List[T]:
     """ Function for extracting the unique elements of a list while preserving the original order of the elements
 
@@ -111,3 +112,22 @@ def unique(elements: List[T]) -> List[T]:
         The list of unique elements
     """
     return list(dict.fromkeys(elements))
+
+
+def is_rectangular(map: List[List[T]]) -> bool:
+    """ A helper function for checking whether or not a 2D map of elements is rectangular or not
+
+    Parameters
+    ----------
+    map : List[List[T]]
+        The 2D Map to be checked
+
+    Returns
+    -------
+    True if the 2D Map is rectangular, False otherwise
+    """
+
+    if len(map)    == 0:                                           return False
+    if len(map[0]) == 0:                                           return False
+    if any([len(map[i]) != len(map[0]) for i in range(len(map))]): return False
+    return True

--- a/test/unit/test_assembly.py
+++ b/test/unit/test_assembly.py
@@ -1,0 +1,74 @@
+import pytest
+from math import isclose
+from numpy.testing import assert_allclose
+
+from mpactpy.assembly import Assembly
+from test.unit.test_material import material, equal_material, unequal_material
+from test.unit.test_pinmesh import general_cylindrical_pinmesh as pinmesh,\
+                                   equal_general_cylindrical_pinmesh as equal_pinmesh,\
+                                   unequal_general_cylindrical_pinmesh as unequal_pinmesh
+from test.unit.test_pin import pin, equal_pin, unequal_pin
+from test.unit.test_module import module, equal_module, unequal_module
+from test.unit.test_lattice import lattice, equal_lattice, unequal_lattice
+
+
+@pytest.fixture
+def assembly(lattice):
+    return Assembly([lattice, lattice,
+                     lattice, lattice])
+
+@pytest.fixture
+def equal_assembly(equal_lattice):
+    return Assembly([equal_lattice, equal_lattice,
+                     equal_lattice, equal_lattice])
+
+@pytest.fixture
+def unequal_assembly(unequal_lattice):
+    return Assembly([unequal_lattice, unequal_lattice,
+                     unequal_lattice, unequal_lattice])
+
+def test_assembly_initialization(assembly, lattice):
+    assert isclose(assembly.height, 12.0)
+    assert assembly.nz == 4
+
+    assert_allclose([assembly.pitch[i] for i in ['X','Y']], [8., 8.])
+    assert_allclose([assembly.mod_dim[i] for i in ['X','Y']], [4., 4.])
+    assert_allclose(assembly.mod_dim['Z'], [3.])
+    assert all([l == lattice for l in assembly.lattice_map])
+    assert len(assembly.lattices)  == 1
+    assert len(assembly.modules)   == 1
+    assert len(assembly.pins)      == 1
+    assert len(assembly.pinmeshes) == 1
+    assert len(assembly.materials) == 1
+
+def test_assembly_equality(assembly, equal_assembly, unequal_assembly):
+    assert assembly == equal_assembly
+    assert assembly != unequal_assembly
+
+def test_assembly_hash(assembly, equal_assembly, unequal_assembly):
+    assert hash(assembly) == hash(equal_assembly)
+    assert hash(assembly) != hash(unequal_assembly)
+
+def test_assembly_write_to_string(assembly):
+    output = assembly.write_to_string(prefix="  ")
+    expected_output = "  assembly 1\n" + \
+                      "    1 1 1 1\n"
+    assert output == expected_output
+
+def test_assembly_set_unique_elements(lattice):
+    assembly = Assembly([lattice, lattice,
+                         lattice, lattice])
+
+    other_lattice = lattice
+    assembly.set_unique_elements([other_lattice])
+    assert all([l is other_lattice for l in assembly.lattice_map])
+
+def test_assembly_get_axial_slice(assembly):
+    assembly_slice = assembly.get_axial_slice(0.5, 1.5)
+    pin_slice      = assembly_slice.pins[-1]
+
+    assert pin_slice.pinmesh.number_of_material_regions == 8
+    assert pin_slice.pinmesh.regions_inside_bounds == [0, 1, 2, 4, 5, 6]
+    assert isclose(assembly_slice.height, 1.0)
+    assert_allclose([assembly_slice.pitch[i] for i in ['X','Y']], [8., 8.])
+    assert_allclose(pin_slice.pinmesh.zvals, [0.5, 1.0])

--- a/test/unit/test_core.py
+++ b/test/unit/test_core.py
@@ -1,0 +1,84 @@
+import pytest
+from math import isclose
+from numpy.testing import assert_allclose
+
+from mpactpy.core import Core
+from test.unit.test_material import material, equal_material, unequal_material
+from test.unit.test_pinmesh import general_cylindrical_pinmesh as pinmesh,\
+                                   equal_general_cylindrical_pinmesh as equal_pinmesh,\
+                                   unequal_general_cylindrical_pinmesh as unequal_pinmesh
+from test.unit.test_pin import pin, equal_pin, unequal_pin
+from test.unit.test_module import module, equal_module, unequal_module
+from test.unit.test_lattice import lattice, equal_lattice, unequal_lattice
+from test.unit.test_assembly import assembly, equal_assembly, unequal_assembly
+
+
+@pytest.fixture
+def core(assembly):
+    return Core([[None,     assembly, None    ],
+                 [assembly, assembly, assembly],
+                 [None,     assembly, None    ]])
+
+@pytest.fixture
+def equal_core(equal_assembly):
+    return Core([[None,           equal_assembly, None          ],
+                 [equal_assembly, equal_assembly, equal_assembly],
+                 [None,           equal_assembly, None          ]])
+
+@pytest.fixture
+def unequal_core(unequal_assembly):
+    return Core([[None,             unequal_assembly, None            ],
+                 [unequal_assembly, unequal_assembly, unequal_assembly],
+                 [None,             unequal_assembly, None            ]])
+
+def test_core_initialization(core, assembly):
+    assert isclose(core.height, 12.0)
+    assert core.symmetry_opt    == ""
+    assert core.quarter_sym_opt == ""
+    assert core.nx              == 3
+    assert core.ny              == 3
+    assert core.nz              == 4
+
+    assert_allclose([core.mod_dim[i] for i in ['X','Y']], [4., 4.])
+    assert_allclose(core.mod_dim['Z'], [3.])
+    assert all([a == assembly for row in core.assembly_map for a in row if a])
+    assert len(core.assemblies)    == 1
+    assert len(assembly.lattices)  == 1
+    assert len(assembly.modules)   == 1
+    assert len(assembly.pins)      == 1
+    assert len(assembly.pinmeshes) == 1
+    assert len(assembly.materials) == 1
+
+def test_core_equality(core, equal_core, unequal_core):
+    assert core == equal_core
+    assert core != unequal_core
+
+def test_core_hash(core, equal_core, unequal_core):
+    assert hash(core) == hash(equal_core)
+    assert hash(core) != hash(unequal_core)
+
+def test_core_write_to_string(core):
+    output = core.write_to_string(prefix="  ")
+    expected_output = "  core\n" + \
+                      "      1  \n" + \
+                      "    1 1 1\n" + \
+                      "      1  \n"
+    assert output == expected_output
+
+def test_core_set_unique_elements(assembly):
+    core = Core([[None,     assembly, None    ],
+                 [assembly, assembly, assembly],
+                 [None,     assembly, None    ]])
+
+    other_assembly = assembly
+    core.set_unique_elements([other_assembly])
+    assert all([a is other_assembly for row in core.assembly_map for a in row if a])
+
+def test_core_get_axial_slice(core):
+    core_slice = core.get_axial_slice(0.5, 1.5)
+    pin_slice  = core_slice.pins[-1]
+
+    assert pin_slice.pinmesh.number_of_material_regions == 8
+    assert pin_slice.pinmesh.regions_inside_bounds == [0, 1, 2, 4, 5, 6]
+    assert isclose(core_slice.height, 1.0)
+    assert_allclose(pin_slice.pinmesh.zvals, [0.5, 1.0])

--- a/test/unit/test_core.py
+++ b/test/unit/test_core.py
@@ -2,6 +2,10 @@ import pytest
 from math import isclose
 from numpy.testing import assert_allclose
 
+from mpactpy.pin import build_rec_pin
+from mpactpy.module import Module
+from mpactpy.lattice import Lattice
+from mpactpy.assembly import Assembly
 from mpactpy.core import Core
 from test.unit.test_material import material, equal_material, unequal_material
 from test.unit.test_pinmesh import general_cylindrical_pinmesh as pinmesh,\
@@ -74,3 +78,34 @@ def test_core_get_axial_slice(core):
     assert pin_slice.pinmesh.regions_inside_bounds == [0, 1, 2, 4, 5, 6]
     assert isclose(core_slice.height, 1.0)
     assert_allclose(pin_slice.pinmesh.zvals, [0.5, 1.0])
+
+def test_core_axial_mesh_unionization(material):
+
+    pin_1 = build_rec_pin(thicknesses = {"X": [1.0], "Y": [3.0], "Z": [4.0]},
+                          materials   = [material])
+
+    pin_2 = build_rec_pin(thicknesses = {"X": [1.0], "Y": [3.0], "Z": [1.0]},
+                          materials   = [material])
+
+    mod_1 = Module(1, [[pin_1]])
+    mod_2 = Module(1, [[pin_2]])
+    lat_1 = Lattice([[mod_1]])
+    lat_2 = Lattice([[mod_2]])
+    asy_1 = Assembly([lat_1])
+    asy_2 = Assembly([lat_2, lat_2, lat_2, lat_2])
+
+    core = Core([[asy_1, asy_2],
+                 [asy_1, asy_1,]])
+
+    assert core.nx == 2
+    assert core.ny == 2
+    assert core.nz == 4
+
+    assert_allclose(core.mod_dim['Z'], [1.])
+    assert all([a == asy_2 for row in core.assembly_map for a in row if a])
+    assert len(core.assemblies) == 1
+    assert len(core.lattices)   == 1
+    assert len(core.modules)    == 1
+    assert len(core.pins)       == 1
+    assert len(core.pinmeshes)  == 1
+    assert len(core.materials)  == 1

--- a/test/unit/test_core.py
+++ b/test/unit/test_core.py
@@ -60,9 +60,9 @@ def test_core_hash(core, equal_core, unequal_core):
 def test_core_write_to_string(core):
     output = core.write_to_string(prefix="  ")
     expected_output = "  core\n" + \
-                      "      1  \n" + \
+                      "      1\n" + \
                       "    1 1 1\n" + \
-                      "      1  \n"
+                      "      1\n"
     assert output == expected_output
 
 def test_core_set_unique_elements(assembly):

--- a/test/unit/test_lattice.py
+++ b/test/unit/test_lattice.py
@@ -61,8 +61,7 @@ def test_lattice_set_unique_elements(module):
 
 def test_lattice_get_axial_slice(lattice):
     lattice_slice = lattice.get_axial_slice(0.5, 1.5)
-    module_slice  = lattice_slice.modules[-1]
-    pin_slice     = module_slice.pins[-1]
+    pin_slice     = lattice_slice.pins[-1]
 
     assert pin_slice.pinmesh.number_of_material_regions == 8
     assert pin_slice.pinmesh.regions_inside_bounds == [0, 1, 2, 4, 5, 6]

--- a/test/unit/test_lattice.py
+++ b/test/unit/test_lattice.py
@@ -1,0 +1,70 @@
+import pytest
+from numpy.testing import assert_allclose
+
+from mpactpy.lattice import Lattice
+from test.unit.test_material import material, equal_material, unequal_material
+from test.unit.test_pinmesh import general_cylindrical_pinmesh as pinmesh,\
+                                   equal_general_cylindrical_pinmesh as equal_pinmesh,\
+                                   unequal_general_cylindrical_pinmesh as unequal_pinmesh
+from test.unit.test_pin import pin, equal_pin, unequal_pin
+from test.unit.test_module import module, equal_module, unequal_module
+
+
+@pytest.fixture
+def lattice(module):
+    return Lattice([[module, module],
+                    [module, module]])
+
+@pytest.fixture
+def equal_lattice(equal_module):
+    return Lattice([[equal_module, equal_module],
+                    [equal_module, equal_module]])
+
+@pytest.fixture
+def unequal_lattice(unequal_module):
+    return Lattice([[unequal_module, unequal_module],
+                    [unequal_module, unequal_module]])
+
+def test_lattice_initialization(lattice, module):
+    assert lattice.nx == 2
+    assert lattice.ny == 2
+
+    assert_allclose([lattice.pitch[i] for i in ['X','Y','Z']], [8., 8., 3.])
+    assert all([m == module for row in lattice.module_map for m in row])
+    assert len(lattice.modules)   == 1
+    assert len(lattice.pins)      == 1
+    assert len(lattice.pinmeshes) == 1
+    assert len(lattice.materials) == 1
+
+def test_lattice_equality(lattice, equal_lattice, unequal_lattice):
+    assert lattice == equal_lattice
+    assert lattice != unequal_lattice
+
+def test_lattice_hash(lattice, equal_lattice, unequal_lattice):
+    assert hash(lattice) == hash(equal_lattice)
+    assert hash(lattice) != hash(unequal_lattice)
+
+def test_lattice_write_to_string(lattice):
+    output = lattice.write_to_string(prefix="  ")
+    expected_output = "  lattice 1 2 2\n" + \
+                      "    1 1\n" + \
+                      "    1 1\n"
+    assert output == expected_output
+
+def test_lattice_set_unique_elements(module):
+    lattice = Lattice([[module, module],
+                       [module, module]])
+
+    other_module = module
+    lattice.set_unique_elements([other_module])
+    assert all([m is other_module for row in lattice.module_map for m in row])
+
+def test_lattice_get_axial_slice(lattice):
+    lattice_slice = lattice.get_axial_slice(0.5, 1.5)
+    module_slice  = lattice_slice.modules[-1]
+    pin_slice     = module_slice.pins[-1]
+
+    assert pin_slice.pinmesh.number_of_material_regions == 8
+    assert pin_slice.pinmesh.regions_inside_bounds == [0, 1, 2, 4, 5, 6]
+    assert_allclose([lattice_slice.pitch[i] for i in ['X','Y','Z']], [8., 8., 1.])
+    assert_allclose(pin_slice.pinmesh.zvals, [0.5, 1.0])

--- a/test/unit/test_material.py
+++ b/test/unit/test_material.py
@@ -12,7 +12,7 @@ def material():
     dens             = 10.0
     temp             = 300.0
     numd             = {"U235": 1e-3, "H": 2e-3}
-    mpact_id         = 42
+    mpact_id         = 1
     thermal_scat_iso = ["H"]
     return Material(mat_type, dens, temp, numd, mpact_id, thermal_scat_iso)
 
@@ -22,7 +22,7 @@ def equal_material():
     dens             = 10.0*(1+TOL)
     temp             = 300.0*(1-TOL)
     numd             = {"U235": 1e-3*(1+TOL), "H": 2e-3*(1-TOL)}
-    mpact_id         = 42
+    mpact_id         = 1
     thermal_scat_iso = ["H"]
     return Material(mat_type, dens, temp, numd, mpact_id, thermal_scat_iso)
 
@@ -32,13 +32,13 @@ def unequal_material():
     dens             = 5.0
     temp             = 300.0
     numd             = {"U235": 1e-3, "H": 2e-3}
-    mpact_id         = 42
+    mpact_id         = 1
     thermal_scat_iso = ["H"]
     return Material(mat_type, dens, temp, numd, mpact_id, thermal_scat_iso)
 
 
 def test_material_initialization(material):
-    assert material.mpact_id == 42
+    assert material.mpact_id == 1
     assert material.material_type == 1
     assert isclose(material.density, 10.0)
     assert isclose(material.temperature, 300.0)
@@ -80,7 +80,7 @@ def test_isotope_MPACT_ID():
 
 def test_material_write_to_string(material):
     output = material.write_to_string(prefix="  ")
-    expected_output = ("  mat 42 1 10.0 g/cc 300.0 K \\\n"
+    expected_output = ("  mat 1 1 10.0 g/cc 300.0 K \\\n"
                        "    1001 0.002\n"
                        "    92235 0.001\n")
     assert output == expected_output

--- a/test/unit/test_material.py
+++ b/test/unit/test_material.py
@@ -4,7 +4,7 @@ from mpactpy.material import Material
 from mpactpy.utils import ROUNDING_RELATIVE_TOLERANCE
 import openmc
 
-TOL = ROUNDING_RELATIVE_TOLERANCE * 1E-1
+TOL = ROUNDING_RELATIVE_TOLERANCE * 1E-2
 
 @pytest.fixture
 def material():

--- a/test/unit/test_material.py
+++ b/test/unit/test_material.py
@@ -8,34 +8,42 @@ TOL = ROUNDING_RELATIVE_TOLERANCE * 1E-1
 
 @pytest.fixture
 def material():
-    mat_type         = 1
     dens             = 10.0
     temp             = 300.0
     numd             = {"U235": 1e-3, "H": 2e-3}
     thermal_scat_iso = ["H"]
-    return Material(mat_type, dens, temp, numd, thermal_scat_iso)
+    is_fluid         = True
+    is_depl          = False
+    has_res          = False
+    is_fuel          = False
+    return Material(dens, temp, numd, thermal_scat_iso, is_fluid, is_depl, has_res, is_fuel)
 
 @pytest.fixture
 def equal_material():
-    mat_type         = 1
     dens             = 10.0*(1+TOL)
     temp             = 300.0*(1-TOL)
     numd             = {"U235": 1e-3*(1+TOL), "H": 2e-3*(1-TOL)}
     thermal_scat_iso = ["H"]
-    return Material(mat_type, dens, temp, numd, thermal_scat_iso)
+    is_fluid         = True
+    is_depl          = False
+    has_res          = False
+    is_fuel          = False
+    return Material(dens, temp, numd, thermal_scat_iso, is_fluid, is_depl, has_res, is_fuel)
 
 @pytest.fixture
 def unequal_material():
-    mat_type         = 1
     dens             = 5.0
     temp             = 300.0
     numd             = {"U235": 1e-3, "H": 2e-3}
     thermal_scat_iso = ["H"]
-    return Material(mat_type, dens, temp, numd, thermal_scat_iso)
+    is_fluid         = True
+    is_depl          = False
+    has_res          = False
+    is_fuel          = False
+    return Material(dens, temp, numd, thermal_scat_iso, is_fluid, is_depl, has_res, is_fuel)
 
 
 def test_material_initialization(material):
-    assert material.material_type == 1
     assert isclose(material.density, 10.0)
     assert isclose(material.temperature, 300.0)
     assert material.number_densities == {"U235": 1e-3, "H": 2e-3}
@@ -57,10 +65,8 @@ def test_material_from_openmc_material():
     openmc_material.add_nuclide('H1', 2e-3)
 
     material = Material.from_openmc_material(material                    = openmc_material,
-                                             material_type               = 1,
                                              thermal_scattering_isotopes = ["H1"])
 
-    assert material.material_type == 1
     assert isclose(material.density, 10.0)
     assert isclose(material.temperature, 300.0)
     assert material.number_densities["U235"] == openmc_material.get_nuclide_atom_densities()["U235"]

--- a/test/unit/test_material.py
+++ b/test/unit/test_material.py
@@ -1,16 +1,43 @@
 import pytest
 from math import isclose
 from mpactpy.material import Material
+from mpactpy.utils import ROUNDING_RELATIVE_TOLERANCE
 import openmc
 
-def test_material_initialization():
-    material = Material(material_type              = 1,
-                       density                     = 10.0,
-                       temperature                 = 300.0,
-                       number_densities            = {"U235": 1e-3, "H": 2e-3},
-                       mpact_id                    = 42,
-                       thermal_scattering_isotopes = ["H"])
+TOL = ROUNDING_RELATIVE_TOLERANCE * 1E-1
 
+@pytest.fixture
+def material():
+    mat_type         = 1
+    dens             = 10.0
+    temp             = 300.0
+    numd             = {"U235": 1e-3, "H": 2e-3}
+    mpact_id         = 42
+    thermal_scat_iso = ["H"]
+    return Material(mat_type, dens, temp, numd, mpact_id, thermal_scat_iso)
+
+@pytest.fixture
+def equal_material():
+    mat_type         = 1
+    dens             = 10.0*(1+TOL)
+    temp             = 300.0*(1-TOL)
+    numd             = {"U235": 1e-3*(1+TOL), "H": 2e-3*(1-TOL)}
+    mpact_id         = 42
+    thermal_scat_iso = ["H"]
+    return Material(mat_type, dens, temp, numd, mpact_id, thermal_scat_iso)
+
+@pytest.fixture
+def unequal_material():
+    mat_type         = 1
+    dens             = 5.0
+    temp             = 300.0
+    numd             = {"U235": 1e-3, "H": 2e-3}
+    mpact_id         = 42
+    thermal_scat_iso = ["H"]
+    return Material(mat_type, dens, temp, numd, mpact_id, thermal_scat_iso)
+
+
+def test_material_initialization(material):
     assert material.mpact_id == 42
     assert material.material_type == 1
     assert isclose(material.density, 10.0)
@@ -18,31 +45,13 @@ def test_material_initialization():
     assert material.number_densities == {"U235": 1e-3, "H": 2e-3}
     assert material.thermal_scattering_isotopes == ["H"]
 
-def test_material_equality():
-    material1 = Material(material_type=1, density=10.0, temperature=300.0, number_densities={"U235": 1e-3, "O16": 2e-3})
-    material2 = Material(material_type=1, density=10.0, temperature=300.0, number_densities={"U235": 1e-3, "O16": 2e-3})
-    material3 = Material(material_type=2, density=10.0, temperature=300.0, number_densities={"U235": 1e-3, "O16": 2e-3})
+def test_material_equality(material, equal_material, unequal_material):
+    assert material == equal_material
+    assert material != unequal_material
 
-    assert material1 == material2
-    assert material1 != material3
-
-def test_material_hash():
-    material1 = Material(material_type    = 1,
-                         density          = 10.0,
-                         temperature      = 300.0,
-                         number_densities = {"U235": 1e-3, "O16": 2e-3},
-                         mpact_id         = 42)
-
-    # Create a second material with slightly different values within the tolerance
-    material2 = Material(material_type    = 1,
-                         density          = 10.0 * (1 + 1E-6),
-                         temperature      = 300.0 * (1 - 1E-6),
-                         number_densities = {"U235": 1e-3 * (1 + 1E-6),
-                                             "O16" : 2e-3 * (1 - 1E-6)},
-                         mpact_id         = 42)
-
-    assert material1 == material2, "Materials should be equal within tolerance."
-    assert hash(material1) == hash(material2), "Hashes should match for equal materials."
+def test_material_hash(material, equal_material, unequal_material):
+    assert hash(material) == hash(equal_material)
+    assert hash(material) != hash(unequal_material)
 
 def test_material_from_openmc_material():
     openmc_material = openmc.Material()
@@ -69,17 +78,9 @@ def test_isotope_MPACT_ID():
     assert Material.isotope_MPACT_ID("H1", False) == 1001
     assert Material.isotope_MPACT_ID("C", True) == 6001
 
-def test_material_write_to_string():
-    material = Material(material_type               = 1,
-                        density                     = 10.0,
-                        temperature                 = 300.0,
-                        number_densities            = {"U235": 1e-3, "O16": 2e-3},
-                        mpact_id                    = 42)
-
+def test_material_write_to_string(material):
     output = material.write_to_string(prefix="  ")
-
     expected_output = ("  mat 42 1 10.0 g/cc 300.0 K \\\n"
-                       "    8016 0.002\n"
+                       "    1001 0.002\n"
                        "    92235 0.001\n")
-
     assert output == expected_output

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -1,0 +1,209 @@
+import pytest
+from math import isclose
+from numpy.testing import assert_allclose
+
+from mpactpy.material import Material
+from mpactpy.pinmesh import RectangularPinMesh, GeneralCylindricalPinMesh
+from mpactpy.pin import Pin
+from mpactpy.module import Module
+from mpactpy.lattice import Lattice
+from mpactpy.assembly import Assembly
+from mpactpy.core import Core
+from mpactpy.model import Model
+from test.unit.test_material import material, equal_material, unequal_material
+from test.unit.test_pinmesh import general_cylindrical_pinmesh as pinmesh,\
+                                   equal_general_cylindrical_pinmesh as equal_pinmesh,\
+                                   unequal_general_cylindrical_pinmesh as unequal_pinmesh
+from test.unit.test_pin import pin, equal_pin, unequal_pin
+from test.unit.test_module import module, equal_module, unequal_module
+from test.unit.test_lattice import lattice, equal_lattice, unequal_lattice
+from test.unit.test_assembly import assembly, equal_assembly, unequal_assembly
+from test.unit.test_core import core, equal_core, unequal_core
+
+
+@pytest.fixture
+def model(core):
+    return Model(core          = core,
+                 states        = [{"power": "0.0"}],
+                 xsec_settings = {"xslib": "ORNL mpact_lib.fmt"},
+                 options       = {"bound_cond": "1 1 1 1 1 1"})
+
+@pytest.fixture
+def equal_model(equal_core):
+    return Model(core          = equal_core,
+                 states        = [{"power": "0.0"}],
+                 xsec_settings = {"xslib": "ORNL mpact_lib.fmt"},
+                 options       = {"bound_cond": "1 1 1 1 1 1"})
+
+@pytest.fixture
+def unequal_model(unequal_core):
+    return Model(core          = unequal_core,
+                 states        = [{"power": "0.0"}],
+                 xsec_settings = {"xslib": "ORNL mpact_lib.fmt"},
+                 options       = {"bound_cond": "1 1 1 1 1 1"})
+
+def test_core_initialization(model, core):
+    assert model.core          == core
+    assert model.states        == [{"power": "0.0"}]
+    assert model.xsec_settings == {"xslib": "ORNL mpact_lib.fmt"}
+    assert model.options       == {"bound_cond": "1 1 1 1 1 1"}
+
+def test_model_equality(model, equal_model, unequal_model):
+    assert model == equal_model
+    assert model != unequal_model
+
+def test_model_hash(model, equal_model, unequal_model):
+    assert hash(model) == hash(equal_model)
+    assert hash(model) != hash(unequal_model)
+
+def test_model_write_to_string(model):
+    output = model.write_to_string(caseid="test", indent=2)
+    expected_output = \
+"""CASEID test
+
+MATERIAL
+  mat 1 1 10.0 g/cc 300.0 K \\
+    1001 0.002
+    92235 0.001
+
+STATE power 0.0
+
+GEOM
+  mod_dim 4.0 4.0 3.0
+
+  pinmesh 1 gcyl 0.5 1.0 / -1.0 1.0 -1.0 1.0 / 1.0 2.0 3.0 / 1 2 / 8 8 8 8 / 5 5 5
+
+  pin 1 1 / 1 1 1 1 1 1 1 1 1
+
+  module 1 2 2 1
+    1 1
+    1 1
+
+  lattice 1 2 2
+    1 1
+    1 1
+
+  assembly 1
+    1 1 1 1
+
+  core
+      1
+    1 1 1
+      1
+
+XSEC
+  xslib ORNL mpact_lib.fmt
+
+OPTION
+  bound_cond 1 1 1 1 1 1
+
+"""
+    assert output == expected_output
+
+
+
+def test_harder_model():
+    """ This tests a harder model with multiple repeated element definitions that the model
+        must successfully NOT repeat when writing to string
+    """
+    mat = [Material(1, 10.0, 300.0, {"U235": 1e-3, "H": 2e-3}, 1, ["H"]),
+           Material(1, 10.0, 300.0, {"U235": 5e-3, "H": 8e-3}, 2, ["H"])]
+
+    pin_meshes = [RectangularPinMesh([0.5, 1.0], [0.5, 1.0], [1.0], [2, 2], [1, 1], [1]),
+                  RectangularPinMesh([0.5, 1.0], [0.5, 1.0], [2.0], [2, 2], [1, 1], [1]),
+                  GeneralCylindricalPinMesh([0.25, 0.5, 1.0], -0.5, 0.5, -0.5, 0.5, [1.0], [1, 1, 1], [16, 16, 16, 16], [1]), # Tests having a radius that falls outside the bounds
+                  GeneralCylindricalPinMesh([0.25, 0.5],      -0.5, 0.5, -0.5, 0.5, [2.0], [1, 2], [16, 16, 16, 16], [1]),
+                  RectangularPinMesh([0.5, 1.0], [0.5, 1.0], [1.0], [2, 2], [1, 1], [1])] # Adding a repeated pin mesh to test filtering of repeated pin meshes
+
+    p = [Pin(pin_meshes[4], [mat[0], mat[0], mat[0], mat[0]]),
+         Pin(pin_meshes[1], [mat[0], mat[0], mat[0], mat[0]]),
+         Pin(pin_meshes[2], [mat[1], mat[1], mat[0], mat[1]]),  # Tests having a radius that falls outside the bounds.  The last material should not be written
+         Pin(pin_meshes[3], [mat[1], mat[1], mat[0]]),
+         Pin(pin_meshes[0], [mat[0], mat[0], mat[0], mat[0]])] # Adding a repeated to test filtering of repeated
+
+    m = [Module(1, [[p[0],p[2]],
+                    [p[2],p[0]]]),
+
+         Module(1, [[p[2],p[0]],
+                    [p[0],p[2]]]),
+
+         Module(1, [[p[3],p[1]],
+                    [p[1],p[3]]]),
+
+         Module(1, [[p[0],p[2]],
+                    [p[2],p[4]]])] # Adding a repeated to test filtering of repeated
+
+    l = [Lattice([[m[3]]]),
+         Lattice([[m[2]]]),
+         Lattice([[m[1]]]),
+         Lattice([[m[0]]])] # Adding a repeated to test filtering of repeated
+
+    a = [Assembly([l[2], l[0], l[1], l[0]]),
+         Assembly([l[0], l[2], l[1], l[2]]),
+         Assembly([l[2], l[0], l[1], l[3]])] # Adding a repeated assembly to test filtering of repeated
+
+    output = Model(core          = Core(symmetry_opt = "360", assembly_map = [[a[0],a[1]],
+                                                                              [a[1],a[2]]]),
+                   states        = [{"power": "0.0"}],
+                   xsec_settings = {"xslib": "ORNL mpact_lib.fmt"},
+                   options       = {"bound_cond": "1 1 1 1 1 1"}).write_to_string(caseid="test", indent=2)
+    expected_output = \
+"""CASEID test
+
+MATERIAL
+  mat 1 1 10.0 g/cc 300.0 K \\
+    1001 0.008
+    92235 0.005
+  mat 2 1 10.0 g/cc 300.0 K \\
+    1001 0.002
+    92235 0.001
+
+STATE power 0.0
+
+GEOM
+  mod_dim 2.0 2.0 1.0 2.0
+
+  pinmesh 1 gcyl 0.25 0.5 / -0.5 0.5 -0.5 0.5 / 1.0 / 1 1 / 16 16 16 / 1
+  pinmesh 2 rec 0.5 1.0 / 0.5 1.0 / 1.0 / 2 2 / 1 1 / 1
+  pinmesh 3 gcyl 0.25 0.5 / -0.5 0.5 -0.5 0.5 / 2.0 / 1 2 / 16 16 16 16 / 1
+  pinmesh 4 rec 0.5 1.0 / 0.5 1.0 / 2.0 / 2 2 / 1 1 / 1
+
+  pin 1 1 / 1 1 2
+  pin 2 2 / 2 2 2 2
+  pin 3 3 / 1 1 2
+  pin 4 4 / 2 2 2 2
+
+  module 1 2 2 1
+    1 2
+    2 1
+  module 2 2 2 1
+    2 1
+    1 2
+  module 3 2 2 1
+    3 4
+    4 3
+
+  lattice 1 1 1
+    1
+  lattice 2 1 1
+    2
+  lattice 3 1 1
+    3
+
+  assembly 1
+    1 2 3 2
+  assembly 2
+    2 1 3 1
+
+  core 360
+    1 2
+    2 1
+
+XSEC
+  xslib ORNL mpact_lib.fmt
+
+OPTION
+  bound_cond 1 1 1 1 1 1
+
+"""
+    assert output == expected_output

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -106,8 +106,8 @@ def test_harder_model():
     """ This tests a harder model with multiple repeated element definitions that the model
         must successfully NOT repeat when writing to string
     """
-    mat = [Material(1, 10.0, 300.0, {"U235": 1e-3, "H": 2e-3}, ["H"]),
-           Material(1, 10.0, 300.0, {"U235": 5e-3, "H": 8e-3}, ["H"])]
+    mat = [Material(10.0, 300.0, {"U235": 1e-3, "H": 2e-3}, ["H"]),
+           Material(10.0, 300.0, {"U235": 5e-3, "H": 8e-3}, ["H"])]
 
     pin_meshes = [RectangularPinMesh([0.5, 1.0], [0.5, 1.0], [1.0], [2, 2], [1, 1], [1]),
                   RectangularPinMesh([0.5, 1.0], [0.5, 1.0], [2.0], [2, 2], [1, 1], [1]),
@@ -151,10 +151,10 @@ def test_harder_model():
 """CASEID test
 
 MATERIAL
-  mat 1 1 10.0 g/cc 300.0 K \\
+  mat 1 0 10.0 g/cc 300.0 K \\
     1001 0.008
     92235 0.005
-  mat 2 1 10.0 g/cc 300.0 K \\
+  mat 2 0 10.0 g/cc 300.0 K \\
     1001 0.002
     92235 0.001
 

--- a/test/unit/test_module.py
+++ b/test/unit/test_module.py
@@ -1,0 +1,67 @@
+import pytest
+from numpy.testing import assert_allclose
+
+from mpactpy.module import Module
+from test.unit.test_material import material, equal_material, unequal_material
+from test.unit.test_pinmesh import general_cylindrical_pinmesh as pinmesh,\
+                                   equal_general_cylindrical_pinmesh as equal_pinmesh,\
+                                   unequal_general_cylindrical_pinmesh as unequal_pinmesh
+from test.unit.test_pin import pin, equal_pin, unequal_pin
+
+
+@pytest.fixture
+def module(pin):
+    return Module(1, [[pin, pin],
+                      [pin, pin]])
+
+@pytest.fixture
+def equal_module(equal_pin):
+    return Module(1, [[equal_pin, equal_pin],
+                      [equal_pin, equal_pin]])
+
+@pytest.fixture
+def unequal_module(unequal_pin):
+    return Module(1, [[unequal_pin, unequal_pin],
+                      [unequal_pin, unequal_pin]])
+
+def test_module_initialization(module, pin):
+    assert module.nx == 2
+    assert module.ny == 2
+    assert module.nz == 1
+    assert_allclose([module.pitch[i] for i in ['X','Y','Z']], [4., 4., 3.])
+    assert all([p == pin for row in module.pin_map for p in row])
+    assert len(module.pins)      == 1
+    assert len(module.pinmeshes) == 1
+    assert len(module.materials) == 1
+
+def test_module_equality(module, equal_module, unequal_module):
+    assert module == equal_module
+    assert module != unequal_module
+
+def test_module_hash(module, equal_module, unequal_module):
+    assert hash(module) == hash(equal_module)
+    assert hash(module) != hash(unequal_module)
+
+def test_module_write_to_string(module):
+    output = module.write_to_string(prefix="  ")
+    expected_output = "  module 1 2 2 1\n" + \
+                      "    1 1\n" + \
+                      "    1 1\n"
+    assert output == expected_output
+
+def test_module_set_unique_elements(pin):
+    module = Module(1, [[pin, pin],
+                        [pin, pin]])
+
+    other_pin = pin
+    module.set_unique_elements([other_pin])
+    assert all([p is other_pin for row in module.pin_map for p in row])
+
+def test_module_get_axial_slice(module):
+    module_slice = module.get_axial_slice(0.5, 1.5)
+    pin_slice    = module_slice.pins[-1]
+
+    assert pin_slice.pinmesh.number_of_material_regions == 8
+    assert pin_slice.pinmesh.regions_inside_bounds == [0, 1, 2, 4, 5, 6]
+    assert_allclose([pin_slice.pinmesh.pitch[i] for i in ['X','Y','Z']], [2., 2., 1.])
+    assert_allclose(pin_slice.pinmesh.zvals, [0.5, 1.0])

--- a/test/unit/test_module.py
+++ b/test/unit/test_module.py
@@ -63,5 +63,5 @@ def test_module_get_axial_slice(module):
 
     assert pin_slice.pinmesh.number_of_material_regions == 8
     assert pin_slice.pinmesh.regions_inside_bounds == [0, 1, 2, 4, 5, 6]
-    assert_allclose([pin_slice.pinmesh.pitch[i] for i in ['X','Y','Z']], [2., 2., 1.])
+    assert_allclose([module_slice.pitch[i] for i in ['X','Y','Z']], [4., 4., 1.])
     assert_allclose(pin_slice.pinmesh.zvals, [0.5, 1.0])

--- a/test/unit/test_pin.py
+++ b/test/unit/test_pin.py
@@ -1,6 +1,7 @@
 import pytest
 from numpy.testing import assert_allclose
-from mpactpy.pin import Pin
+from mpactpy.pinmesh import RectangularPinMesh, GeneralCylindricalPinMesh
+from mpactpy.pin import Pin, build_rec_pin, build_gcyl_pin
 from test.unit.test_material import material, equal_material, unequal_material
 from test.unit.test_pinmesh import general_cylindrical_pinmesh as pinmesh,\
                                    equal_general_cylindrical_pinmesh as equal_pinmesh,\
@@ -61,3 +62,35 @@ def test_pin_axial_merge(pin):
     assert len(merged_pin.pinmesh.ndivz) == 6
     assert_allclose([merged_pin.pinmesh.pitch[i] for i in ['X','Y','Z']], [2., 2., 6.])
     assert_allclose(merged_pin.pinmesh.zvals, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+
+def test_build_gcyl_pin(material):
+    pin = build_gcyl_pin(bounds                  = (-2.5, 2.5, -2.5, 2.5),
+                         thicknesses             = {"R": [2.0], "Z": [1.0]},
+                         materials               = [material, material],
+                         target_cell_thicknesses = {"R": 1.0, "S": 6.0, "Z": 0.5})
+
+    materials    = [material, material, material]
+    pin_mesh     = GeneralCylindricalPinMesh(r     = [1.0, 2.0],
+                                             xMin  = -2.5, xMax = 2.5,
+                                             yMin  = -2.5, yMax = 2.5,
+                                             zvals = [1.0],
+                                             ndivr = [1, 1], ndiva = [4, 4, 4], ndivz = [2])
+    expected_pin = Pin(pin_mesh, materials)
+
+    assert pin == expected_pin
+
+def test_build_rec_pin(material):
+    pin = build_rec_pin(thicknesses             = {"X": [1.0, 1.0], "Y": [3.0], "Z": [5.0]},
+                        materials               = [material, material],
+                        target_cell_thicknesses = {"X": 0.5, "Y": 1.5})
+
+    materials    = [material, material]
+    pin_mesh     = RectangularPinMesh(xvals = [1.0, 2.0],
+                                      yvals = [3.0],
+                                      zvals = [5.0],
+                                      ndivx = [2, 2],
+                                      ndivy = [2],
+                                      ndivz = [1])
+    expected_pin = Pin(pin_mesh, materials)
+
+    assert pin == expected_pin

--- a/test/unit/test_pin.py
+++ b/test/unit/test_pin.py
@@ -1,0 +1,72 @@
+import pytest
+from numpy.testing import assert_allclose
+from mpactpy.pin import Pin
+from test.unit.test_material import material, equal_material, unequal_material
+from test.unit.test_pinmesh import general_cylindrical_pinmesh as pinmesh,\
+                                   equal_general_cylindrical_pinmesh as equal_pinmesh,\
+                                   unequal_general_cylindrical_pinmesh as unequal_pinmesh
+
+
+@pytest.fixture
+def pin(material, pinmesh):
+    materials = [material for _ in range(pinmesh.number_of_material_regions)]
+    return Pin(pinmesh, materials)
+
+@pytest.fixture
+def equal_pin(equal_material, equal_pinmesh):
+    materials = [equal_material for _ in range(equal_pinmesh.number_of_material_regions)]
+    return Pin(equal_pinmesh, materials)
+
+@pytest.fixture
+def unequal_pin(unequal_material, unequal_pinmesh):
+    materials = [unequal_material for _ in range(unequal_pinmesh.number_of_material_regions)]
+    return Pin(unequal_pinmesh, materials)
+
+def test_pin_initialization(pin, pinmesh, material):
+    number_of_material_regions = pinmesh.number_of_material_regions
+    assert pin.pinmesh        == pinmesh
+    assert len(pin.materials) == number_of_material_regions
+    assert pin.materials      == [material for _ in range(number_of_material_regions)]
+    assert_allclose([pin.pitch[i] for i in ['X','Y','Z']], [2., 2., 3.])
+
+def test_pin_equality(pin, equal_pin, unequal_pin):
+    assert pin == equal_pin
+    assert pin != unequal_pin
+
+def test_pin_hash(pin, equal_pin, unequal_pin):
+    assert hash(pin) == hash(equal_pin)
+    assert hash(pin) != hash(unequal_pin)
+
+def test_pin_write_to_string(pin):
+    output = pin.write_to_string(prefix="test ")
+    expected_output = "test pin 1 1 / 1 1 1 1 1 1 1 1 1\n"
+    assert output == expected_output
+
+def test_pin_set_unique_elements(material, pinmesh):
+    materials = [material for _ in range(pinmesh.number_of_material_regions)]
+    pin = Pin(pinmesh, materials)
+
+    other_material = material
+    other_pinmesh  = pinmesh
+    pin.set_unique_elements([other_pinmesh], [other_material])
+
+    assert pin.pinmesh is other_pinmesh
+    assert all([mat is other_material for mat in pin.materials])
+
+
+def test_pin_get_axial_slice(pin):
+    pin_slice = pin.get_axial_slice(0.5, 1.5)
+
+    assert pin_slice.pinmesh.number_of_material_regions == 8
+    assert pin_slice.pinmesh.regions_inside_bounds == [0, 1, 2, 4, 5, 6]
+    assert_allclose([pin_slice.pinmesh.pitch[i] for i in ['X','Y','Z']], [2., 2., 1.])
+    assert_allclose(pin_slice.pinmesh.zvals, [0.5, 1.0])
+
+def test_pin_axial_merge(pin):
+    merged_pin = pin.axial_merge(pin)
+
+    assert merged_pin.pinmesh.number_of_material_regions == 24
+    assert len(merged_pin.materials) == 24
+    assert len(merged_pin.pinmesh.ndivz) == 6
+    assert_allclose([merged_pin.pinmesh.pitch[i] for i in ['X','Y','Z']], [2., 2., 6.])
+    assert_allclose(merged_pin.pinmesh.zvals, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])

--- a/test/unit/test_pin.py
+++ b/test/unit/test_pin.py
@@ -38,8 +38,8 @@ def test_pin_hash(pin, equal_pin, unequal_pin):
     assert hash(pin) != hash(unequal_pin)
 
 def test_pin_write_to_string(pin):
-    output = pin.write_to_string(prefix="test ")
-    expected_output = "test pin 1 1 / 1 1 1 1 1 1 1 1 1\n"
+    output = pin.write_to_string(prefix="  ")
+    expected_output = "  pin 1 1 / 1 1 1 1 1 1 1 1 1\n"
     assert output == expected_output
 
 def test_pin_set_unique_elements(material, pinmesh):

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -62,8 +62,8 @@ def test_rectangular_pinmesh_hash(rectangular_pinmesh,
     assert hash(rectangular_pinmesh) != hash(unequal_rectangular_pinmesh)
 
 def test_rectangular_pinmesh_write_to_string(rectangular_pinmesh):
-    output = rectangular_pinmesh.write_to_string(prefix="test ")
-    expected_output = "test pinmesh 1 rec 1.0 2.0 3.0 / 1.0 2.0 3.0 / 1.0 2.0 3.0 / 10 10 10 / 10 10 10 / 5 5 5\n"
+    output = rectangular_pinmesh.write_to_string(prefix="  ")
+    expected_output = "  pinmesh 1 rec 1.0 2.0 3.0 / 1.0 2.0 3.0 / 1.0 2.0 3.0 / 10 10 10 / 10 10 10 / 5 5 5\n"
     assert output == expected_output
 
 

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 from mpactpy.utils import ROUNDING_RELATIVE_TOLERANCE
 from mpactpy.pinmesh import RectangularPinMesh, GeneralCylindricalPinMesh
 
-TOL = ROUNDING_RELATIVE_TOLERANCE * 1E-1
+TOL = ROUNDING_RELATIVE_TOLERANCE * 1E-2
 
 @pytest.fixture
 def rectangular_pinmesh():

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -1,0 +1,83 @@
+import pytest
+from math import isclose
+from numpy.testing import assert_allclose
+from mpactpy.pinmesh import RectangularPinMesh, GeneralCylindricalPinMesh
+
+@pytest.fixture
+def rectangular_pinmesh():
+    xvals = [1.0, 2.0, 3.0]
+    yvals = [1.0, 2.0, 3.0]
+    zvals = [1.0, 2.0, 3.0]
+    ndivx = [10, 10, 10]
+    ndivy = [10, 10, 10]
+    ndivz = [5, 5, 5]
+    return RectangularPinMesh(xvals, yvals, zvals, ndivx, ndivy, ndivz, id=1)
+
+def test_rectangular_pinmesh_initialization(rectangular_pinmesh):
+    pinmesh = rectangular_pinmesh
+    assert pinmesh.id == 1
+    assert pinmesh.number_of_material_regions == 27
+    assert pinmesh.regions_inside_bounds == 27
+    assert_allclose(pinmesh.xvals, [1.0, 2.0, 3.0])
+    assert_allclose(pinmesh.yvals, [1.0, 2.0, 3.0])
+    assert_allclose(pinmesh.zvals, [1.0, 2.0, 3.0])
+    assert_allclose(pinmesh.ndivx, [10, 10, 10])
+    assert_allclose(pinmesh.ndivy, [10, 10, 10])
+    assert_allclose(pinmesh.ndivz, [5, 5, 5])
+
+def test_rectangular_pinmesh_equality(rectangular_pinmesh):
+    pinmesh1 = rectangular_pinmesh
+    pinmesh2 = rectangular_pinmesh
+    assert pinmesh1 == pinmesh2
+
+def test_rectangular_pinmesh_hash(rectangular_pinmesh):
+    pinmesh1 = rectangular_pinmesh
+    pinmesh2 = rectangular_pinmesh
+    assert hash(pinmesh1) == hash(pinmesh2)
+
+def test_rectangular_pinmesh_write_to_string(rectangular_pinmesh):
+    output = rectangular_pinmesh.write_to_string(prefix="test ")
+    expected_output = "test pinmesh 1 rec 1.0 2.0 3.0 / 1.0 2.0 3.0 / 1.0 2.0 3.0 / 10 10 10 / 10 10 10 / 5 5 5\n"
+    assert output == expected_output
+
+
+@pytest.fixture
+def general_cylindrical_pinmesh():
+    r = [0.5, 1.0, 1.5]
+    xMin, xMax = -1.0, 1.0
+    yMin, yMax = -1.0, 1.0
+    zvals = [1.0, 2.0, 3.0]
+    ndivr = [1, 2, 2]
+    ndiva = [8, 8, 8, 8, 8, 8]
+    ndivz = [5, 5, 5]
+    return GeneralCylindricalPinMesh(r, xMin, xMax, yMin, yMax, zvals, ndivr, ndiva, ndivz, id=1)
+
+def test_general_cylindrical_pinmesh_initialization(general_cylindrical_pinmesh):
+    pinmesh = general_cylindrical_pinmesh
+    assert pinmesh.id == 1
+    assert pinmesh.number_of_material_regions == 12
+    assert pinmesh.regions_inside_bounds == [0, 1, 2, 4, 5, 6, 8, 9, 10]
+    assert isclose(pinmesh.xMin, -1.0)
+    assert isclose(pinmesh.xMax,  1.0)
+    assert isclose(pinmesh.yMin, -1.0)
+    assert isclose(pinmesh.yMax,  1.0)
+    assert_allclose(pinmesh.r,     [0.5, 1.0, 1.5])
+    assert_allclose(pinmesh.zvals, [1.0, 2.0, 3.0])
+    assert_allclose(pinmesh.ndivr, [1, 2, 2])
+    assert_allclose(pinmesh.ndiva, [8, 8, 8, 8, 8, 8])
+    assert_allclose(pinmesh.ndivz, [5, 5, 5])
+
+def test_general_cylindrical_pinmesh_equality(general_cylindrical_pinmesh):
+    pinmesh1 = general_cylindrical_pinmesh
+    pinmesh2 = general_cylindrical_pinmesh
+    assert pinmesh1 == pinmesh2
+
+def test_general_cylindrical_pinmesh_hash(general_cylindrical_pinmesh):
+    pinmesh1 = general_cylindrical_pinmesh
+    pinmesh2 = general_cylindrical_pinmesh
+    assert hash(pinmesh1) == hash(pinmesh2)
+
+def test_general_cylindrical_pinmesh_write_to_string(general_cylindrical_pinmesh):
+    output = general_cylindrical_pinmesh.write_to_string(prefix="test ")
+    expected_output = "test pinmesh 1 gcyl 0.5 1.0 / -1.0 1.0 -1.0 1.0 / 1.0 2.0 3.0 / 1 2 / 8 8 8 8 / 5 5 5\n"
+    assert output == expected_output

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -1,7 +1,10 @@
 import pytest
 from math import isclose
 from numpy.testing import assert_allclose
+from mpactpy.utils import ROUNDING_RELATIVE_TOLERANCE
 from mpactpy.pinmesh import RectangularPinMesh, GeneralCylindricalPinMesh
+
+TOL = ROUNDING_RELATIVE_TOLERANCE * 1E-1
 
 @pytest.fixture
 def rectangular_pinmesh():
@@ -11,11 +14,31 @@ def rectangular_pinmesh():
     ndivx = [10, 10, 10]
     ndivy = [10, 10, 10]
     ndivz = [5, 5, 5]
-    return RectangularPinMesh(xvals, yvals, zvals, ndivx, ndivy, ndivz, id=1)
+    return RectangularPinMesh(xvals, yvals, zvals, ndivx, ndivy, ndivz, mpact_id=1)
+
+@pytest.fixture
+def equal_rectangular_pinmesh():
+    xvals = [1.0*(1+TOL), 2.0*(1-TOL), 3.0*(1+TOL)]
+    yvals = [1.0*(1-TOL), 2.0*(1+TOL), 3.0*(1+TOL)]
+    zvals = [1.0*(1+TOL), 2.0*(1+TOL), 3.0*(1-TOL)]
+    ndivx = [10, 10, 10]
+    ndivy = [10, 10, 10]
+    ndivz = [5, 5, 5]
+    return RectangularPinMesh(xvals, yvals, zvals, ndivx, ndivy, ndivz, mpact_id=1)
+
+@pytest.fixture
+def unequal_rectangular_pinmesh():
+    xvals = [1.0, 2.0, 5.0]
+    yvals = [1.0, 2.0, 3.0]
+    zvals = [1.0, 2.0, 3.0]
+    ndivx = [10, 10, 10]
+    ndivy = [10, 10, 10]
+    ndivz = [5, 5, 5]
+    return RectangularPinMesh(xvals, yvals, zvals, ndivx, ndivy, ndivz, mpact_id=1)
 
 def test_rectangular_pinmesh_initialization(rectangular_pinmesh):
     pinmesh = rectangular_pinmesh
-    assert pinmesh.id == 1
+    assert pinmesh.mpact_id == 1
     assert pinmesh.number_of_material_regions == 27
     assert pinmesh.regions_inside_bounds == 27
     assert_allclose(pinmesh.xvals, [1.0, 2.0, 3.0])
@@ -25,15 +48,17 @@ def test_rectangular_pinmesh_initialization(rectangular_pinmesh):
     assert_allclose(pinmesh.ndivy, [10, 10, 10])
     assert_allclose(pinmesh.ndivz, [5, 5, 5])
 
-def test_rectangular_pinmesh_equality(rectangular_pinmesh):
-    pinmesh1 = rectangular_pinmesh
-    pinmesh2 = rectangular_pinmesh
-    assert pinmesh1 == pinmesh2
+def test_rectangular_pinmesh_equality(rectangular_pinmesh,
+                                      equal_rectangular_pinmesh,
+                                      unequal_rectangular_pinmesh):
+    assert rectangular_pinmesh == equal_rectangular_pinmesh
+    assert rectangular_pinmesh != unequal_rectangular_pinmesh
 
-def test_rectangular_pinmesh_hash(rectangular_pinmesh):
-    pinmesh1 = rectangular_pinmesh
-    pinmesh2 = rectangular_pinmesh
-    assert hash(pinmesh1) == hash(pinmesh2)
+def test_rectangular_pinmesh_hash(rectangular_pinmesh,
+                                  equal_rectangular_pinmesh,
+                                  unequal_rectangular_pinmesh):
+    assert hash(rectangular_pinmesh) == hash(equal_rectangular_pinmesh)
+    assert hash(rectangular_pinmesh) != hash(unequal_rectangular_pinmesh)
 
 def test_rectangular_pinmesh_write_to_string(rectangular_pinmesh):
     output = rectangular_pinmesh.write_to_string(prefix="test ")
@@ -50,11 +75,33 @@ def general_cylindrical_pinmesh():
     ndivr = [1, 2, 2]
     ndiva = [8, 8, 8, 8, 8, 8]
     ndivz = [5, 5, 5]
-    return GeneralCylindricalPinMesh(r, xMin, xMax, yMin, yMax, zvals, ndivr, ndiva, ndivz, id=1)
+    return GeneralCylindricalPinMesh(r, xMin, xMax, yMin, yMax, zvals, ndivr, ndiva, ndivz, mpact_id=1)
+
+@pytest.fixture
+def equal_general_cylindrical_pinmesh():
+    r = [0.5*(1+TOL), 1.0*(1-TOL), 1.5*(1+TOL)]
+    xMin, xMax = -1.0*(1+TOL), 1.0*(1-TOL)
+    yMin, yMax = -1.0*(1-TOL), 1.0*(1+TOL)
+    zvals = [1.0*(1-TOL), 2.0*(1+TOL), 3.0*(1-TOL)]
+    ndivr = [1, 2, 2]
+    ndiva = [8, 8, 8, 8, 8, 8]
+    ndivz = [5, 5, 5]
+    return GeneralCylindricalPinMesh(r, xMin, xMax, yMin, yMax, zvals, ndivr, ndiva, ndivz, mpact_id=1)
+
+@pytest.fixture
+def unequal_general_cylindrical_pinmesh():
+    r = [0.5, 1.0, 1.4]
+    xMin, xMax = -1.0, 1.0
+    yMin, yMax = -1.0, 1.0
+    zvals = [1.0, 2.0, 3.0]
+    ndivr = [1, 2, 2]
+    ndiva = [8, 8, 8, 8, 8, 8]
+    ndivz = [5, 5, 5]
+    return GeneralCylindricalPinMesh(r, xMin, xMax, yMin, yMax, zvals, ndivr, ndiva, ndivz, mpact_id=1)
 
 def test_general_cylindrical_pinmesh_initialization(general_cylindrical_pinmesh):
     pinmesh = general_cylindrical_pinmesh
-    assert pinmesh.id == 1
+    assert pinmesh.mpact_id == 1
     assert pinmesh.number_of_material_regions == 12
     assert pinmesh.regions_inside_bounds == [0, 1, 2, 4, 5, 6, 8, 9, 10]
     assert isclose(pinmesh.xMin, -1.0)
@@ -67,15 +114,17 @@ def test_general_cylindrical_pinmesh_initialization(general_cylindrical_pinmesh)
     assert_allclose(pinmesh.ndiva, [8, 8, 8, 8, 8, 8])
     assert_allclose(pinmesh.ndivz, [5, 5, 5])
 
-def test_general_cylindrical_pinmesh_equality(general_cylindrical_pinmesh):
-    pinmesh1 = general_cylindrical_pinmesh
-    pinmesh2 = general_cylindrical_pinmesh
-    assert pinmesh1 == pinmesh2
+def test_general_cylindrical_pinmesh_equality(general_cylindrical_pinmesh,
+                                              equal_general_cylindrical_pinmesh,
+                                              unequal_general_cylindrical_pinmesh):
+        assert general_cylindrical_pinmesh == equal_general_cylindrical_pinmesh
+        assert general_cylindrical_pinmesh != unequal_general_cylindrical_pinmesh
 
-def test_general_cylindrical_pinmesh_hash(general_cylindrical_pinmesh):
-    pinmesh1 = general_cylindrical_pinmesh
-    pinmesh2 = general_cylindrical_pinmesh
-    assert hash(pinmesh1) == hash(pinmesh2)
+def test_general_cylindrical_pinmesh_hash(general_cylindrical_pinmesh,
+                                          equal_general_cylindrical_pinmesh,
+                                          unequal_general_cylindrical_pinmesh):
+    assert hash(general_cylindrical_pinmesh) == hash(equal_general_cylindrical_pinmesh)
+    assert hash(general_cylindrical_pinmesh) != hash(unequal_general_cylindrical_pinmesh)
 
 def test_general_cylindrical_pinmesh_write_to_string(general_cylindrical_pinmesh):
     output = general_cylindrical_pinmesh.write_to_string(prefix="test ")

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -40,7 +40,7 @@ def test_rectangular_pinmesh_initialization(rectangular_pinmesh):
     pinmesh = rectangular_pinmesh
     assert pinmesh.mpact_id == 1
     assert pinmesh.number_of_material_regions == 27
-    assert pinmesh.regions_inside_bounds == 27
+    assert pinmesh.regions_inside_bounds == [i for i in range(27)]
     assert_allclose([pinmesh.pitch[i] for i in ['X','Y','Z']], [3., 3., 3.])
     assert_allclose(pinmesh.xvals, [1.0, 2.0, 3.0])
     assert_allclose(pinmesh.yvals, [1.0, 2.0, 3.0])

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -41,6 +41,7 @@ def test_rectangular_pinmesh_initialization(rectangular_pinmesh):
     assert pinmesh.mpact_id == 1
     assert pinmesh.number_of_material_regions == 27
     assert pinmesh.regions_inside_bounds == 27
+    assert_allclose([pinmesh.pitch[i] for i in ['X','Y','Z']], [3., 3., 3.])
     assert_allclose(pinmesh.xvals, [1.0, 2.0, 3.0])
     assert_allclose(pinmesh.yvals, [1.0, 2.0, 3.0])
     assert_allclose(pinmesh.zvals, [1.0, 2.0, 3.0])
@@ -104,6 +105,7 @@ def test_general_cylindrical_pinmesh_initialization(general_cylindrical_pinmesh)
     assert pinmesh.mpact_id == 1
     assert pinmesh.number_of_material_regions == 12
     assert pinmesh.regions_inside_bounds == [0, 1, 2, 4, 5, 6, 8, 9, 10]
+    assert_allclose([pinmesh.pitch[i] for i in ['X','Y','Z']], [2., 2., 3.])
     assert isclose(pinmesh.xMin, -1.0)
     assert isclose(pinmesh.xMax,  1.0)
     assert isclose(pinmesh.yMin, -1.0)


### PR DESCRIPTION
This refactors the handling of Material MPACT Typing so that users interface Boolean attributes like `is_fuel` or `is_depletable` rather than the raw MPACT Material Type enumerations.