### PR TITLE
OpenMC Overlay Operation

### DIFF
--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -31,10 +31,7 @@ jobs:
       run: |
         source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
         mkdir -p $HOME/openmc-xs
-        openmc_data_downloader -l ENDFB-7.1-NNDC \
-          -i U O H C c_Graphite \
-          --include-elementals \
-          -d $HOME/openmc-xs
+        openmc_data_downloader -l ENDFB-7.1-NNDC -e U O H C -s c_Graphite -d $HOME/openmc-xs
         echo "OPENMC_CROSS_SECTIONS=$HOME/openmc-xs/cross_sections.xml" >> $GITHUB_ENV
 
     - name: Install and Test MPACTPy

--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -35,5 +35,5 @@ jobs:
     - name: Install and Test MPACTPy
       run: |
         source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
-        pytest -v --maxfail=1
+        pytest -v -s --maxfail=1
         python -m pylint ./mpactpy

--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set Up and Configure Environment
       run: |
         conda install -n base -y mamba -c conda-forge
-        mamba create -n openmc-env -y python=3.11 openmc hdf5 mpi4py numpy scipy pandas -c conda-forge
+        mamba create -n openmc-env -y python=3.11 openmc openmc-data hdf5 mpi4py numpy scipy pandas -c conda-forge
         source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
         python -m pip install pylint pytest
 

--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -31,7 +31,11 @@ jobs:
       run: |
         source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
         mkdir -p $HOME/openmc-xs
-        openmc_data_downloader -l ENDFB-7.1-NNDC -e U O H C -s c_Graphite -d $HOME/openmc-xs
+        openmc_data_downloader -l ENDFB-7.1-NNDC \
+          -e U O H C \
+          -i U234 U235 U236 U238 O16 H1 H2 C \
+          -s c_Graphite \
+          -d $HOME/openmc-xs
         echo "OPENMC_CROSS_SECTIONS=$HOME/openmc-xs/cross_sections.xml" >> $GITHUB_ENV
 
     - name: Install and Test MPACTPy

--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -29,11 +29,11 @@ jobs:
 
     - name: Download and Set Up OpenMC Cross Sections
       run: |
-        sudo apt-get update && sudo apt-get install -y wget unzip
+        sudo apt-get update && sudo apt-get install -y wget tar
         mkdir -p $HOME/openmc-xs
         cd $HOME/openmc-xs
-        wget https://github.com/openmc-dev/data/releases/download/v0.12-nndc-endf-b-vii.1/endf-b-vii.1-hdf5.zip
-        unzip endf-b-vii.1-hdf5.zip
+        wget https://openmc.org/official-data-libraries/endf-b-vii.1-hdf5.tar.xz
+        tar -xf endf-b-vii.1-hdf5.tar.xz
         echo "OPENMC_CROSS_SECTIONS=$HOME/openmc-xs/endf-b-vii.1-hdf5/cross_sections.xml" >> $GITHUB_ENV
 
     - name: Install and Test MPACTPy

--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -30,5 +30,7 @@ jobs:
     - name: Install and Test MPACTPy
       run: |
         source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
+        which openmc
+        openmc --version
         pytest -v -s --maxfail=1
         python -m pylint ./mpactpy

--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -6,11 +6,6 @@ on:
     # Run every day at 8:00 AM UTC (3:00 AM CDT)
     - cron: '0 8 * * *'
 
-env:
-  OMP_NUM_THREADS: 1
-  OPENBLAS_NUM_THREADS: 1
-  MKL_NUM_THREADS: 1
-
 jobs:
   build-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -29,12 +29,9 @@ jobs:
 
     - name: Download and Set Up OpenMC Cross Sections
       run: |
-        sudo apt-get update && sudo apt-get install -y wget tar
-        mkdir -p $HOME/openmc-xs
-        cd $HOME/openmc-xs
-        wget https://openmc.org/official-data-libraries/endf-b-vii.1-hdf5.tar.xz
-        tar -xf endf-b-vii.1-hdf5.tar.xz
-        echo "OPENMC_CROSS_SECTIONS=$HOME/openmc-xs/endf-b-vii.1-hdf5/cross_sections.xml" >> $GITHUB_ENV
+        source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
+        openmc-get-nndc-data --destination $HOME/openmc-xs
+        echo "OPENMC_CROSS_SECTIONS=$HOME/openmc-xs/cross_sections.xml" >> $GITHUB_ENV
 
     - name: Install and Test MPACTPy
       run: |

--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -23,9 +23,18 @@ jobs:
     - name: Set Up and Configure Environment
       run: |
         conda install -n base -y mamba -c conda-forge
-        mamba create -n openmc-env -y python=3.11 openmc openmc-data hdf5 mpi4py numpy scipy pandas -c conda-forge
+        mamba create -n openmc-env -y python=3.11 openmc hdf5 mpi4py numpy scipy pandas -c conda-forge
         source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
         python -m pip install pylint pytest
+
+    - name: Download and Set Up OpenMC Cross Sections
+      run: |
+        sudo apt-get update && sudo apt-get install -y wget unzip
+        mkdir -p $HOME/openmc-xs
+        cd $HOME/openmc-xs
+        wget https://github.com/openmc-dev/data/releases/download/v0.12-nndc-endf-b-vii.1/endf-b-vii.1-hdf5.zip
+        unzip endf-b-vii.1-hdf5.zip
+        echo "OPENMC_CROSS_SECTIONS=$HOME/openmc-xs/endf-b-vii.1-hdf5/cross_sections.xml" >> $GITHUB_ENV
 
     - name: Install and Test MPACTPy
       run: |

--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -25,12 +25,13 @@ jobs:
         conda install -n base -y mamba -c conda-forge
         mamba create -n openmc-env -y python=3.11 openmc hdf5 mpi4py numpy scipy pandas -c conda-forge
         source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
-        python -m pip install pylint pytest
+        python -m pip install pylint pytest openmc_data_downloader
 
     - name: Download and Set Up OpenMC Cross Sections
       run: |
-        source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
-        openmc-get-nndc-data --destination $HOME/openmc-xs
+        sudo apt-get update && sudo apt-get install -y wget tar
+        mkdir -p $HOME/openmc-xs
+        openmc_data_downloader -l ENDFB-7.1-NNDC -d $HOME/openmc-xs
         echo "OPENMC_CROSS_SECTIONS=$HOME/openmc-xs/cross_sections.xml" >> $GITHUB_ENV
 
     - name: Install and Test MPACTPy

--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -31,7 +31,10 @@ jobs:
       run: |
         source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
         mkdir -p $HOME/openmc-xs
-        openmc_data_downloader -l ENDFB-7.1-NNDC -d $HOME/openmc-xs
+        openmc_data_downloader -l ENDFB-7.1-NNDC \
+          -i U O H C c_Graphite \
+          --include-elementals \
+          -d $HOME/openmc-xs
         echo "OPENMC_CROSS_SECTIONS=$HOME/openmc-xs/cross_sections.xml" >> $GITHUB_ENV
 
     - name: Install and Test MPACTPy

--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -6,6 +6,11 @@ on:
     # Run every day at 8:00 AM UTC (3:00 AM CDT)
     - cron: '0 8 * * *'
 
+env:
+  OMP_NUM_THREADS: 1
+  OPENBLAS_NUM_THREADS: 1
+  MKL_NUM_THREADS: 1
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest
@@ -30,5 +35,5 @@ jobs:
     - name: Install and Test MPACTPy
       run: |
         source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
-        pytest
+        pytest -v --maxfail=1
         python -m pylint ./mpactpy

--- a/.github/workflows/mpactpy.yml
+++ b/.github/workflows/mpactpy.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Download and Set Up OpenMC Cross Sections
       run: |
-        sudo apt-get update && sudo apt-get install -y wget tar
+        source $(conda info --base)/etc/profile.d/conda.sh && conda activate openmc-env
         mkdir -p $HOME/openmc-xs
         openmc_data_downloader -l ENDFB-7.1-NNDC -d $HOME/openmc-xs
         echo "OPENMC_CROSS_SECTIONS=$HOME/openmc-xs/cross_sections.xml" >> $GITHUB_ENV

--- a/mpactpy/pin.py
+++ b/mpactpy/pin.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
-from typing import Dict, List, Any, Union, TypedDict, Tuple
+from typing import Dict, List, Any, Union, TypedDict, Tuple, Set, Optional
 from math import isclose, inf, pi
 from copy import deepcopy
 from itertools import accumulate
+
+import openmc
 
 from mpactpy.material import Material
 from mpactpy.pinmesh import PinMesh, RectangularPinMesh, GeneralCylindricalPinMesh
@@ -204,6 +206,50 @@ class Pin():
         pinmesh.set_axial_mesh([height], [1])
 
         return Pin(pinmesh, self.materials)
+
+
+    OverlayMask = Set[Material]
+
+    def overlay(self,
+                model:          openmc.Model,
+                offset:         Tuple[float, float, float] = (0.0, 0.0, 0.0),
+                include_only:   Optional[OverlayMask] = None,
+                overlay_policy: PinMesh.OverlayPolicy = PinMesh.OverlayPolicy()) -> Pin:
+        """ A method for overlaying an OpenMC model over top an MPACTPy Pin
+
+        Parameters
+        ----------
+        model : openmc.Model
+            The OpenMC Model to be mapped onto the MPACTPy Pin
+        offset : Tuple(float, float, float)
+            Offset of the OpenMC geometry's lower-left corner relative to the
+            MPACT PinMesh lower-left. Default is (0.0, 0.0, 0.0)
+        include_only : Optional[OverlayMask]
+            Specifies which MPACT elements should be considered during overlay.
+            If None, all elements are included.
+        overlay_policy : OverlayPolicy
+            A configuration object specifying how a mesh overlay should be done.
+
+        Returns
+        -------
+        Pin
+            A new MPACTPy Pin which is a copy of the original,
+            but with the OpenMC Model overlaid on top.
+        """
+
+        include_mats: Pin.OverlayMask = include_only if include_only else set(self.materials)
+
+        openmc_materials = self.pinmesh.overlay(model, offset, overlay_policy)
+        assert len(openmc_materials) == len(self.materials), \
+            f"len(openmc_materials) = {len(openmc_materials)} " + \
+            f"len(self.materials) = {len(self.materials)}"
+
+        new_materials = [openmc_mat if openmc_mat and (old_mat in include_mats) else old_mat
+                         for openmc_mat, old_mat in zip(openmc_materials, self.materials)]
+
+        return Pin(self.pinmesh, new_materials)
+
+
 
 
 def build_rec_pin(thicknesses:             Dict[str, List[float]],

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -345,17 +345,6 @@ class RectangularPinMesh(PinMesh):
         ny = len(self.yvals)
         nz = len(self.zvals)
 
-        if overlay_policy.num_procs > 1:
-            print("== DEBUG ==", flush=True)
-            print("Working dir:", os.getcwd(), flush=True)
-            print("Files:", os.listdir(), flush=True)
-            model.export_to_xml()
-            print("Exported geometry.xml:", os.path.exists("geometry.xml"), flush=True)
-            print("Exported materials.xml:", os.path.exists("materials.xml"), flush=True)
-            print("OpenMC path:", openmc.config.get('openmc'), flush=True)
-            print("OMP_NUM_THREADS:", os.environ.get("OMP_NUM_THREADS"), flush=True)
-            print("Calling mesh.material_volumes()...", flush=True)
-            print("OpenMC binary path:", openmc.config.get('openmc'), flush=True)
         materials = []
         if overlay_policy.method == "centroid":
             centroids = mesh.centroids.reshape((-1, 3))

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -357,6 +357,17 @@ class RectangularPinMesh(PinMesh):
             arr = np.array(materials).reshape((nx, ny, nz), order='F')
             materials = arr.flatten(order='C').tolist()
         else:
+            print("== DEBUG ==")
+            print("Working dir:", os.getcwd())
+            print("Files:", os.listdir())
+            model.export_to_xml()
+            print("Exported geometry.xml:", os.path.exists("geometry.xml"))
+            print("Exported materials.xml:", os.path.exists("materials.xml"))
+            print("OpenMC path:", openmc.config.get('openmc'))
+            print("OMP_NUM_THREADS:", os.environ.get("OMP_NUM_THREADS"))
+            print("Calling mesh.material_volumes()...")
+            print("OpenMC binary path:", openmc.config.get('openmc'))
+            model.settings.run_mode = 'volume'
             with temporary_environment("OMP_NUM_THREADS", str(overlay_policy.num_procs)):
                 material_volumes = mesh.material_volumes(model, overlay_policy.n_samples)
 

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -357,10 +357,6 @@ class RectangularPinMesh(PinMesh):
             arr = np.array(materials).reshape((nx, ny, nz), order='F')
             materials = arr.flatten(order='C').tolist()
         else:
-            model.export_to_xml()
-            print(os.path.exists("geometry.xml"))
-            print(os.path.exists("materials.xml"))
-            print("Here")
             with temporary_environment("OMP_NUM_THREADS", str(overlay_policy.num_procs)):
                 material_volumes = mesh.material_volumes(model, overlay_policy.n_samples)
 

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -346,16 +346,16 @@ class RectangularPinMesh(PinMesh):
         nz = len(self.zvals)
 
         if overlay_policy.num_procs > 1:
-            print("== DEBUG ==")
-            print("Working dir:", os.getcwd())
-            print("Files:", os.listdir())
+            print("== DEBUG ==", flush=True)
+            print("Working dir:", os.getcwd(), flush=True)
+            print("Files:", os.listdir(), flush=True)
             model.export_to_xml()
-            print("Exported geometry.xml:", os.path.exists("geometry.xml"))
-            print("Exported materials.xml:", os.path.exists("materials.xml"))
-            print("OpenMC path:", openmc.config.get('openmc'))
-            print("OMP_NUM_THREADS:", os.environ.get("OMP_NUM_THREADS"))
-            print("Calling mesh.material_volumes()...")
-            print("OpenMC binary path:", openmc.config.get('openmc'))
+            print("Exported geometry.xml:", os.path.exists("geometry.xml"), flush=True)
+            print("Exported materials.xml:", os.path.exists("materials.xml"), flush=True)
+            print("OpenMC path:", openmc.config.get('openmc'), flush=True)
+            print("OMP_NUM_THREADS:", os.environ.get("OMP_NUM_THREADS"), flush=True)
+            print("Calling mesh.material_volumes()...", flush=True)
+            print("OpenMC binary path:", openmc.config.get('openmc'), flush=True)
         materials = []
         if overlay_policy.method == "centroid":
             centroids = mesh.centroids.reshape((-1, 3))
@@ -368,7 +368,6 @@ class RectangularPinMesh(PinMesh):
             arr = np.array(materials).reshape((nx, ny, nz), order='F')
             materials = arr.flatten(order='C').tolist()
         else:
-            model.settings.run_mode = 'volume'
             with temporary_environment("OMP_NUM_THREADS", str(overlay_policy.num_procs)):
                 material_volumes = mesh.material_volumes(model, overlay_policy.n_samples)
 

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Any, Tuple, Optional
 from math import isclose, hypot
 from concurrent.futures import ThreadPoolExecutor
-import os
 
 import openmc
 import numpy as np

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Any, Tuple, Optional
 from math import isclose, hypot
 from concurrent.futures import ThreadPoolExecutor
+import os
 
 import openmc
 import numpy as np
@@ -357,6 +358,9 @@ class RectangularPinMesh(PinMesh):
             materials = arr.flatten(order='C').tolist()
         else:
             with temporary_environment("OMP_NUM_THREADS", str(overlay_policy.num_procs)):
+                model.export_to_xml()
+                assert os.path.exists("geometry.xml")
+                assert os.path.exists("materials.xml")
                 material_volumes = mesh.material_volumes(model, overlay_policy.n_samples)
 
             elements = [material_volumes.by_element(i) for i in range(material_volumes.num_elements)]

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -359,8 +359,8 @@ class RectangularPinMesh(PinMesh):
         else:
             with temporary_environment("OMP_NUM_THREADS", str(overlay_policy.num_procs)):
                 model.export_to_xml()
-                assert os.path.exists("geometry.xml")
-                assert os.path.exists("materials.xml")
+                print(os.path.exists("geometry.xml"))
+                print(os.path.exists("materials.xml"))
                 material_volumes = mesh.material_volumes(model, overlay_policy.n_samples)
 
             elements = [material_volumes.by_element(i) for i in range(material_volumes.num_elements)]

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -346,6 +346,10 @@ class RectangularPinMesh(PinMesh):
         nz = len(self.zvals)
 
         materials = []
+        model.export_to_xml()
+        print(os.path.exists("geometry.xml"))
+        print(os.path.exists("materials.xml"))
+        print("Here")
         if overlay_policy.method == "centroid":
             centroids = mesh.centroids.reshape((-1, 3))
             with ThreadPoolExecutor(max_workers=overlay_policy.num_procs) as executor:
@@ -358,9 +362,6 @@ class RectangularPinMesh(PinMesh):
             materials = arr.flatten(order='C').tolist()
         else:
             with temporary_environment("OMP_NUM_THREADS", str(overlay_policy.num_procs)):
-                model.export_to_xml()
-                print(os.path.exists("geometry.xml"))
-                print(os.path.exists("materials.xml"))
                 material_volumes = mesh.material_volumes(model, overlay_policy.n_samples)
 
             elements = [material_volumes.by_element(i) for i in range(material_volumes.num_elements)]

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -346,10 +346,6 @@ class RectangularPinMesh(PinMesh):
         nz = len(self.zvals)
 
         materials = []
-        model.export_to_xml()
-        print(os.path.exists("geometry.xml"))
-        print(os.path.exists("materials.xml"))
-        print("Here")
         if overlay_policy.method == "centroid":
             centroids = mesh.centroids.reshape((-1, 3))
             with ThreadPoolExecutor(max_workers=overlay_policy.num_procs) as executor:
@@ -361,6 +357,10 @@ class RectangularPinMesh(PinMesh):
             arr = np.array(materials).reshape((nx, ny, nz), order='F')
             materials = arr.flatten(order='C').tolist()
         else:
+            model.export_to_xml()
+            print(os.path.exists("geometry.xml"))
+            print(os.path.exists("materials.xml"))
+            print("Here")
             with temporary_environment("OMP_NUM_THREADS", str(overlay_policy.num_procs)):
                 material_volumes = mesh.material_volumes(model, overlay_policy.n_samples)
 

--- a/mpactpy/pinmesh.py
+++ b/mpactpy/pinmesh.py
@@ -345,6 +345,17 @@ class RectangularPinMesh(PinMesh):
         ny = len(self.yvals)
         nz = len(self.zvals)
 
+        if overlay_policy.num_procs > 1:
+            print("== DEBUG ==")
+            print("Working dir:", os.getcwd())
+            print("Files:", os.listdir())
+            model.export_to_xml()
+            print("Exported geometry.xml:", os.path.exists("geometry.xml"))
+            print("Exported materials.xml:", os.path.exists("materials.xml"))
+            print("OpenMC path:", openmc.config.get('openmc'))
+            print("OMP_NUM_THREADS:", os.environ.get("OMP_NUM_THREADS"))
+            print("Calling mesh.material_volumes()...")
+            print("OpenMC binary path:", openmc.config.get('openmc'))
         materials = []
         if overlay_policy.method == "centroid":
             centroids = mesh.centroids.reshape((-1, 3))
@@ -357,16 +368,6 @@ class RectangularPinMesh(PinMesh):
             arr = np.array(materials).reshape((nx, ny, nz), order='F')
             materials = arr.flatten(order='C').tolist()
         else:
-            print("== DEBUG ==")
-            print("Working dir:", os.getcwd())
-            print("Files:", os.listdir())
-            model.export_to_xml()
-            print("Exported geometry.xml:", os.path.exists("geometry.xml"))
-            print("Exported materials.xml:", os.path.exists("materials.xml"))
-            print("OpenMC path:", openmc.config.get('openmc'))
-            print("OMP_NUM_THREADS:", os.environ.get("OMP_NUM_THREADS"))
-            print("Calling mesh.material_volumes()...")
-            print("OpenMC binary path:", openmc.config.get('openmc'))
             model.settings.run_mode = 'volume'
             with temporary_environment("OMP_NUM_THREADS", str(overlay_policy.num_procs)):
                 material_volumes = mesh.material_volumes(model, overlay_policy.n_samples)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.24.0",
-    "openmc>=0.14.0",
+    "openmc>=0.15.2",
 ]
 
 [project.optional-dependencies]

--- a/test/unit/test_core.py
+++ b/test/unit/test_core.py
@@ -2,15 +2,23 @@ import pytest
 from math import isclose
 from numpy.testing import assert_allclose
 
-from mpactpy import build_rec_pin, Module, Lattice, Assembly, Core
+import openmc
+
+from mpactpy import build_rec_pin, PinMesh, Pin, Module, Lattice, Assembly, Core
 from test.unit.test_material import material, equal_material, unequal_material
 from test.unit.test_pinmesh import general_cylindrical_pinmesh as pinmesh,\
                                    equal_general_cylindrical_pinmesh as equal_pinmesh,\
-                                   unequal_general_cylindrical_pinmesh as unequal_pinmesh, pinmesh_2D
-from test.unit.test_pin import pin, equal_pin, unequal_pin, pin_2D
-from test.unit.test_module import module, equal_module, unequal_module, module_2D
-from test.unit.test_lattice import lattice, equal_lattice, unequal_lattice, lattice_2D
-from test.unit.test_assembly import assembly, equal_assembly, unequal_assembly, assembly_2D
+                                   unequal_general_cylindrical_pinmesh as unequal_pinmesh, \
+                                   rectangular_pinmesh as overlay_mesh, \
+                                   pinmesh_2D, openmc_pin, openmc_fuel_material, openmc_moderator_material
+from test.unit.test_pin import pin, equal_pin, unequal_pin, pin_2D, overlay_pin, \
+                               template_material, template_pin
+from test.unit.test_module import module, equal_module, unequal_module, module_2D, \
+                                  template_module, overlay_module, openmc_module
+from test.unit.test_lattice import lattice, equal_lattice, unequal_lattice, lattice_2D, \
+                                   template_lattice, overlay_lattice, openmc_lattice
+from test.unit.test_assembly import assembly, equal_assembly, unequal_assembly, assembly_2D, \
+                                    template_assembly, overlay_assembly, openmc_assembly
 
 
 @pytest.fixture
@@ -36,6 +44,39 @@ def core_2D(assembly_2D):
     return Core([[None,        assembly_2D, None       ],
                  [assembly_2D, assembly_2D, assembly_2D],
                  [None,        assembly_2D, None       ]])
+
+@pytest.fixture
+def template_core(template_assembly):
+    return Core([[None,              template_assembly, None             ],
+                 [template_assembly, template_assembly, template_assembly],
+                 [None,              template_assembly, None             ]])
+
+@pytest.fixture
+def overlay_core(overlay_assembly):
+    return Core([[None,             overlay_assembly, None            ],
+                 [overlay_assembly, overlay_assembly, overlay_assembly],
+                 [None,             overlay_assembly, None            ]])
+
+@pytest.fixture
+def openmc_core(openmc_assembly):
+    model    = openmc_assembly
+    assembly = model.geometry.root_universe
+
+    lattice            = openmc.RectLattice(name='2x2 module lattice')
+    lattice.pitch      = (12.0, 12.0)
+    lattice.lower_left = (-18.0, -18.0, -6.0)
+    lattice.universes  = [[assembly, assembly, assembly],
+                          [assembly, assembly, assembly],
+                          [assembly, assembly, assembly]]
+
+    box           = openmc.model.rectangular_prism(36.0, 36.0, boundary_type='reflective')
+    lattice_cell  = openmc.Cell(name='lattice cell', fill=lattice, region=box)
+
+    universe  = openmc.Universe(cells=[lattice_cell])
+    geometry  = openmc.Geometry(universe)
+    materials = model.materials
+
+    return openmc.Model(geometry=geometry, materials=materials)
 
 def test_core_initialization(core, assembly):
     assert isclose(core.height, 12.0)
@@ -118,3 +159,17 @@ def test_core_with_height(core, core_2D):
 
     with pytest.raises(AssertionError, match=f"nz = {core.nz}, Core must be strictly 2D"):
         new_core = core.with_height(3.0)
+
+def test_module_overlay(openmc_core, template_core, template_assembly, template_lattice, template_module, template_pin, template_material, overlay_core):
+    model                               = openmc_core
+    offset                              = (-18.0, -18.0, -6.0)
+    overlay_policy                      = PinMesh.OverlayPolicy(method="centroid")
+    pin_mask: Pin.OverlayMask           = {template_material}
+    module_mask: Module.OverlayMask     = {template_pin : pin_mask}
+    lattice_mask: Lattice.OverlayMask   = {template_module : module_mask}
+    assembly_mask: Assembly.OverlayMask = {template_lattice : lattice_mask}
+    include_only: Core.OverlayMask      = {template_assembly : assembly_mask}
+
+    core          = template_core.overlay(model, offset, include_only, overlay_policy)
+    expected_core = overlay_core
+    assert core == expected_core

--- a/test/unit/test_material.py
+++ b/test/unit/test_material.py
@@ -1,53 +1,52 @@
 import pytest
 from math import isclose
 from mpactpy import Material
-from mpactpy.utils import ROUNDING_RELATIVE_TOLERANCE
+from mpactpy.utils import atomic_mass, AVOGADRO, ROUNDING_RELATIVE_TOLERANCE
 import openmc
 
 TOL = ROUNDING_RELATIVE_TOLERANCE * 1E-2
 
 @pytest.fixture
 def material():
-    dens             = 10.0
-    temp             = 300.0
-    numd             = {"U235": 1e-3, "H": 2e-3}
-    thermal_scat_iso = ["H"]
-    is_fluid         = True
-    is_depl          = False
-    has_res          = False
-    is_fuel          = False
-    return Material(dens, temp, numd, thermal_scat_iso, is_fluid, is_depl, has_res, is_fuel)
+    temp = 300.0
+    numd = {"U235": 1e-3, "C": 2e-3}
+    spec = Material.MPACTSpecs(thermal_scattering_isotopes = ["C"],
+                               is_fluid                    = True,
+                               is_depletable               = False,
+                               has_resonance               = False,
+                               is_fuel                     = False)
+    return Material(temp, numd, spec)
 
 @pytest.fixture
 def equal_material():
-    dens             = 10.0*(1+TOL)
     temp             = 300.0*(1-TOL)
-    numd             = {"U235": 1e-3*(1+TOL), "H": 2e-3*(1-TOL)}
-    thermal_scat_iso = ["H"]
-    is_fluid         = True
-    is_depl          = False
-    has_res          = False
-    is_fuel          = False
-    return Material(dens, temp, numd, thermal_scat_iso, is_fluid, is_depl, has_res, is_fuel)
+    numd             = {"U235": 1e-3*(1+TOL), "C": 2e-3*(1-TOL)}
+    spec = Material.MPACTSpecs(thermal_scattering_isotopes = ["C"],
+                               is_fluid                    = True,
+                               is_depletable               = False,
+                               has_resonance               = False,
+                               is_fuel                     = False)
+    return Material(temp, numd, spec)
 
 @pytest.fixture
 def unequal_material():
-    dens             = 5.0
-    temp             = 300.0
-    numd             = {"U235": 1e-3, "H": 2e-3}
-    thermal_scat_iso = ["H"]
-    is_fluid         = True
-    is_depl          = False
-    has_res          = False
-    is_fuel          = False
-    return Material(dens, temp, numd, thermal_scat_iso, is_fluid, is_depl, has_res, is_fuel)
+    temp = 600.0
+    numd = {"U238": 2e-3, "O16": 1e-3}
+    spec = Material.MPACTSpecs(thermal_scattering_isotopes = [],
+                               is_fluid                    = False,
+                               is_depletable               = True,
+                               has_resonance               = True,
+                               is_fuel                     = True)
+    return Material(temp, numd, spec)
 
 
 def test_material_initialization(material):
-    assert isclose(material.density, 10.0)
+    expected_density = sum(num_dens * 1e24 * atomic_mass(iso) / AVOGADRO
+                           for iso, num_dens in material.number_densities.items())
+    assert isclose(material.density, expected_density)
     assert isclose(material.temperature, 300.0)
-    assert material.number_densities == {"U235": 1e-3, "H": 2e-3}
-    assert material.thermal_scattering_isotopes == ["H"]
+    assert material.number_densities == {"U235": 1e-3, "C": 2e-3}
+    assert material.thermal_scattering_isotopes == ["C"]
 
 def test_material_equality(material, equal_material, unequal_material):
     assert material == equal_material
@@ -59,19 +58,21 @@ def test_material_hash(material, equal_material, unequal_material):
 
 def test_material_from_openmc_material():
     openmc_material = openmc.Material()
-    openmc_material.set_density('g/cc', 10.0)
+    openmc_material.set_density('sum')
     openmc_material.temperature = 300.0
     openmc_material.add_nuclide('U235', 1e-3)
-    openmc_material.add_nuclide('H1', 2e-3)
+    openmc_material.add_nuclide('C', 2e-3)
 
-    material = Material.from_openmc_material(material                    = openmc_material,
-                                             thermal_scattering_isotopes = ["H1"])
+    material = Material.from_openmc_material(material    = openmc_material,
+                                             mpact_specs = Material.MPACTSpecs(thermal_scattering_isotopes = ["C"]))
 
-    assert isclose(material.density, 10.0)
+    expected_density = sum(num_dens * 1e24 * atomic_mass(iso) / AVOGADRO
+                           for iso, num_dens in material.number_densities.items())
+    assert isclose(material.density, expected_density)
     assert isclose(material.temperature, 300.0)
     assert material.number_densities["U235"] == openmc_material.get_nuclide_atom_densities()["U235"]
-    assert material.number_densities["H1"] == openmc_material.get_nuclide_atom_densities()["H1"]
-    assert material.thermal_scattering_isotopes == ["H1"]
+    assert material.number_densities["C"] == openmc_material.get_nuclide_atom_densities()["C"]
+    assert material.thermal_scattering_isotopes == ["C"]
 
 def test_isotope_MPACT_ID():
     assert Material.isotope_MPACT_ID("U235", False) == 92235
@@ -79,8 +80,47 @@ def test_isotope_MPACT_ID():
     assert Material.isotope_MPACT_ID("C", True) == 6001
 
 def test_material_write_to_string(material):
+    expected_density = sum(num_dens * 1e24 * atomic_mass(iso) / AVOGADRO
+                           for iso, num_dens in material.number_densities.items())
     output = material.write_to_string(prefix="  ", mpact_ids={material: "42"})
-    expected_output = ("  mat 42 1 10.0 g/cc 300.0 K \\\n"
-                       "    1001 0.002\n"
-                       "    92235 0.001\n")
+    expected_output = (f"  mat 42 1 {expected_density} g/cc 300.0 K \\\n"
+                        "    6001 0.002\n"
+                        "    92235 0.001\n")
     assert output == expected_output
+
+def test_material_mix_materials(material, unequal_material):
+
+    policy  = Material.MixPolicy(percent_type='vo', thermal_scattering_policy="intersection")
+    mixture = Material.mix_materials([material, unequal_material], [0.5, 0.5], policy)
+
+    expected_num_dens = {"U235": 0.5 * material.number_densities["U235"],
+                         "C":    0.5 * material.number_densities["C"],
+                         "U238": 0.5 * unequal_material.number_densities["U238"],
+                         "O16":  0.5 * unequal_material.number_densities["O16"]}
+    assert expected_num_dens.keys() == mixture.number_densities.keys()
+    for iso, expected in expected_num_dens.items():
+        assert isclose(mixture.number_densities.get(iso, 0.0), expected, rel_tol=TOL)
+
+    expected_temp = 0.5 * material.temperature + 0.5 * unequal_material.temperature
+    assert isclose(mixture.temperature, expected_temp, rel_tol=TOL)
+
+    expected_density = 0.5 * material.density + 0.5 * unequal_material.density
+    assert isclose(mixture.density, expected_density, rel_tol=TOL)
+
+    assert mixture.is_fluid is False
+    assert mixture.is_depletable is True
+    assert mixture.has_resonance is True
+    assert mixture.is_fuel is True
+    assert mixture.thermal_scattering_isotopes == []
+
+    policy  = Material.MixPolicy(percent_type='wo', thermal_scattering_policy="union", temperature=500.0)
+    mixture = Material.mix_materials([material, unequal_material], [0.5, 0.5], policy)
+
+    assert expected_num_dens.keys() == mixture.number_densities.keys()
+    assert isclose(mixture.temperature, 500.0, rel_tol=TOL)
+
+    inv_densities    = [w / m.density for w, m in zip([0.5, 0.5], [material, unequal_material])]
+    vol_fracs        = [inv_rho / sum(inv_densities) for inv_rho in inv_densities]
+    expected_density = sum(vf * m.density for vf, m in zip(vol_fracs, [material, unequal_material]))
+    assert isclose(mixture.density, expected_density, rel_tol=TOL)
+    assert mixture.thermal_scattering_isotopes == ["C"]

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -50,14 +50,14 @@ def test_model_hash(model, equal_model, unequal_model):
     assert hash(model) == hash(equal_model)
     assert hash(model) != hash(unequal_model)
 
-def test_model_write_to_string(model):
+def test_model_write_to_string(model, material):
     output = model.write_to_string(caseid="test", indent=2)
     expected_output = \
-"""CASEID test
+f"""CASEID test
 
 MATERIAL
-  mat 1 1 10.0 g/cc 300.0 K \\
-    1001 0.002
+  mat 1 1 {material.density} g/cc 300.0 K \\
+    6001 0.002
     92235 0.001
 
 STATE power 0.0
@@ -100,8 +100,9 @@ def test_harder_model():
     """ This tests a harder model with multiple repeated element definitions that the model
         must successfully NOT repeat when writing to string
     """
-    mat = [Material(10.0, 300.0, {"U235": 1e-3, "H": 2e-3}, ["H"]),
-           Material(10.0, 300.0, {"U235": 5e-3, "H": 8e-3}, ["H"])]
+
+    mat = [Material(300.0, {"U235": 1e-3, "H": 2e-3}, Material.MPACTSpecs(thermal_scattering_isotopes=["H"])),
+           Material(300.0, {"U235": 5e-3, "H": 8e-3}, Material.MPACTSpecs(thermal_scattering_isotopes=["H"]))]
 
     pin_meshes = [RectangularPinMesh([0.5, 1.0], [0.5, 1.0], [1.0], [2, 2], [1, 1], [1]),
                   RectangularPinMesh([0.5, 1.0], [0.5, 1.0], [2.0], [2, 2], [1, 1], [1]),
@@ -142,13 +143,13 @@ def test_harder_model():
                    xsec_settings = {"xslib": "ORNL mpact_lib.fmt"},
                    options       = {"bound_cond": "1 1 1 1 1 1"}).write_to_string(caseid="test", indent=2)
     expected_output = \
-"""CASEID test
+f"""CASEID test
 
 MATERIAL
-  mat 1 0 10.0 g/cc 300.0 K \\
+  mat 1 0 {mat[1].density} g/cc 300.0 K \\
     1001 0.008
     92235 0.005
-  mat 2 0 10.0 g/cc 300.0 K \\
+  mat 2 0 {mat[0].density} g/cc 300.0 K \\
     1001 0.002
     92235 0.001
 

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -172,6 +172,7 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
                           M, H, M,
                           M, M, M] * 3
 
+    assert(False)
     assert all(materials_are_close(material, expected_material)
                for material, expected_material in zip(materials, expected_materials))
 

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -157,7 +157,7 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
     M       = Material.from_openmc_material(openmc_moderator_material)
     H       = Material.mix_materials([F, M], [fuel_frac, mod_frac], Material.MixPolicy(percent_type='vo'))
 
-    overlay_policy = PinMesh.OverlayPolicy(method="centroid")
+    overlay_policy = PinMesh.OverlayPolicy(method="centroid", num_procs=2)
     materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
     assert len(materials) == pinmesh.number_of_material_regions
     expected_materials = [M, M, M,
@@ -167,7 +167,7 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
     assert all(materials_are_close(material, expected_material)
                for material, expected_material in zip(materials, expected_materials))
 
-    overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000)
+    overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000, num_procs=2)
     materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
     expected_materials = [M, M, M,
                           M, H, M,

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -1,10 +1,53 @@
 import pytest
-from math import isclose
+from math import isclose, pi
+
 from numpy.testing import assert_allclose
+import openmc
+
+
 from mpactpy.utils import ROUNDING_RELATIVE_TOLERANCE
-from mpactpy import RectangularPinMesh, GeneralCylindricalPinMesh
+from mpactpy import Material
+from mpactpy import PinMesh, RectangularPinMesh, GeneralCylindricalPinMesh
 
 TOL = ROUNDING_RELATIVE_TOLERANCE * 1E-2
+
+@pytest.fixture
+def openmc_fuel_material():
+    fuel = openmc.Material(name='UO2 Fuel', temperature = 300.0)
+    fuel.add_element('U', 1.0, enrichment=4.0)
+    fuel.add_element('O', 2.0)
+    fuel.set_density('g/cm3', 10.0)
+    return fuel
+
+
+@pytest.fixture
+def openmc_moderator_material():
+    moderator = openmc.Material(name='Water', temperature = 300.0)
+    moderator.add_element('H', 2.0)
+    moderator.add_element('O', 1.0)
+    moderator.set_density('g/cm3', 1.0)
+    return moderator
+
+
+@pytest.fixture
+def openmc_pin(openmc_fuel_material, openmc_moderator_material):
+    fuel      = openmc_fuel_material
+    moderator = openmc_moderator_material
+
+    fuel_radius = 0.4
+    pin_pitch   = 3.0
+    fuel_cyl    = openmc.ZCylinder(r=fuel_radius)
+    box         = openmc.model.rectangular_prism(pin_pitch, pin_pitch, boundary_type='reflective')
+
+    fuel_cell      = openmc.Cell(name='fuel', fill=fuel, region=-fuel_cyl)
+    moderator_cell = openmc.Cell(name='moderator', fill=moderator, region=+fuel_cyl & box)
+
+    universe  = openmc.Universe(cells=[fuel_cell, moderator_cell])
+    geometry  = openmc.Geometry(universe)
+    materials = openmc.Materials([fuel, moderator])
+
+    return openmc.Model(geometry=geometry, materials=materials)
+
 
 @pytest.fixture
 def pinmesh_2D():
@@ -46,6 +89,32 @@ def unequal_rectangular_pinmesh():
     ndivz = [5, 5, 5]
     return RectangularPinMesh(xvals, yvals, zvals, ndivx, ndivy, ndivz)
 
+
+def materials_are_close(lhs:     Material,
+                        rhs:     Material,
+                        rel_tol: float = 1E-2) -> bool:
+    """ Helper function for making sure materials are close
+
+    With the isotopic comparisons, different versions of openmc, and particularly
+    different cross-section libraries, will result in different isotopes being
+    associated with 'natural' concentrations.  For this testing, the expected_material
+    is defined using 'fewer' natural isotopes, and the test material must at least
+    have those isotopes.  This allows the test material to have additional `natural`
+    isotopes from using different openmc / xs-library versions and the test still pass.
+    """
+
+    return (isclose(lhs.density, rhs.density, rel_tol=rel_tol)                 and
+            isclose(lhs.temperature, rhs.temperature, rel_tol=rel_tol)         and
+            lhs.thermal_scattering_isotopes == rhs.thermal_scattering_isotopes and
+            lhs.is_fluid                    == rhs.is_fluid                    and
+            lhs.is_depletable               == rhs.is_depletable               and
+            lhs.has_resonance               == rhs.has_resonance               and
+            lhs.is_fuel                     == rhs.is_fuel                     and
+            all(iso in lhs.number_densities.keys() for iso in rhs.number_densities.keys()) and
+            all(isclose(lhs.number_densities[iso], rhs.number_densities[iso], rel_tol=rel_tol)
+                for iso in rhs.number_densities.keys()))
+
+
 def test_rectangular_pinmesh_initialization(rectangular_pinmesh):
     pinmesh = rectangular_pinmesh
     assert pinmesh.number_of_material_regions == 27
@@ -75,6 +144,37 @@ def test_rectangular_pinmesh_write_to_string(rectangular_pinmesh):
     expected_output = "  pinmesh 42 rec 1.0 2.0 3.0 / 1.0 2.0 3.0 / 1.0 2.0 3.0 / 10 10 10 / 10 10 10 / 5 5 5\n"
     assert output == expected_output
 
+def test_rectangular_pinmesh_overlary(rectangular_pinmesh, openmc_fuel_material, openmc_moderator_material, openmc_pin):
+
+    fuel_area = pi*0.4**2
+    box_area  = 1.0*1.0
+    fuel_frac = fuel_area / box_area
+    mod_frac  = 1.0 - fuel_frac
+    offset    = (-1.5, -1.5, 0.0)
+
+    pinmesh = rectangular_pinmesh
+    F       = Material.from_openmc_material(openmc_fuel_material)
+    M       = Material.from_openmc_material(openmc_moderator_material)
+    H       = Material.mix_materials([F, M], [fuel_frac, mod_frac], Material.MixPolicy(percent_type='vo'))
+
+    overlay_policy = PinMesh.OverlayPolicy(method="centroid")
+    materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
+    assert len(materials) == pinmesh.number_of_material_regions
+    expected_materials = [M, M, M,
+                          M, F, M,
+                          M, M, M] * 3
+
+    assert all(materials_are_close(material, expected_material)
+               for material, expected_material in zip(materials, expected_materials))
+
+    overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000, num_procs=2)
+    materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
+    expected_materials = [M, M, M,
+                          M, H, M,
+                          M, M, M] * 3
+
+    assert all(materials_are_close(material, expected_material)
+               for material, expected_material in zip(materials, expected_materials))
 
 @pytest.fixture
 def general_cylindrical_pinmesh():

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -167,14 +167,14 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
     assert all(materials_are_close(material, expected_material)
                for material, expected_material in zip(materials, expected_materials))
 
-    overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000, num_procs=2)
-    materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
-    expected_materials = [M, M, M,
-                          M, H, M,
-                          M, M, M] * 3
-
-    assert all(materials_are_close(material, expected_material)
-               for material, expected_material in zip(materials, expected_materials))
+#    overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000, num_procs=2)
+#    materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
+#    expected_materials = [M, M, M,
+#                          M, H, M,
+#                          M, M, M] * 3
+#
+#    assert all(materials_are_close(material, expected_material)
+#               for material, expected_material in zip(materials, expected_materials))
 
 @pytest.fixture
 def general_cylindrical_pinmesh():

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -167,7 +167,7 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
     assert all(materials_are_close(material, expected_material)
                for material, expected_material in zip(materials, expected_materials))
 
-    overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000, num_procs=)
+    overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000, num_procs=2)
     materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
     expected_materials = [M, M, M,
                           M, H, M,

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -157,7 +157,7 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
     M       = Material.from_openmc_material(openmc_moderator_material)
     H       = Material.mix_materials([F, M], [fuel_frac, mod_frac], Material.MixPolicy(percent_type='vo'))
 
-    print("Here 1")
+    print("Here 1", flush=True)
     overlay_policy = PinMesh.OverlayPolicy(method="centroid", num_procs=2)
     materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
     assert len(materials) == pinmesh.number_of_material_regions
@@ -168,7 +168,7 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
     assert all(materials_are_close(material, expected_material)
                for material, expected_material in zip(materials, expected_materials))
 
-    print("Here 2")
+    print("Here 2", flush=True)
     overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000, num_procs=2)
     materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
     expected_materials = [M, M, M,

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -144,7 +144,7 @@ def test_rectangular_pinmesh_write_to_string(rectangular_pinmesh):
     expected_output = "  pinmesh 42 rec 1.0 2.0 3.0 / 1.0 2.0 3.0 / 1.0 2.0 3.0 / 10 10 10 / 10 10 10 / 5 5 5\n"
     assert output == expected_output
 
-def test_rectangular_pinmesh_overlary(rectangular_pinmesh, openmc_fuel_material, openmc_moderator_material, openmc_pin):
+def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, openmc_moderator_material, openmc_pin):
 
     fuel_area = pi*0.4**2
     box_area  = 1.0*1.0

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -167,14 +167,14 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
     assert all(materials_are_close(material, expected_material)
                for material, expected_material in zip(materials, expected_materials))
 
-#    overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000, num_procs=2)
-#    materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
-#    expected_materials = [M, M, M,
-#                          M, H, M,
-#                          M, M, M] * 3
-#
-#    assert all(materials_are_close(material, expected_material)
-#               for material, expected_material in zip(materials, expected_materials))
+    overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000, num_procs=)
+    materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
+    expected_materials = [M, M, M,
+                          M, H, M,
+                          M, M, M] * 3
+
+    assert all(materials_are_close(material, expected_material)
+               for material, expected_material in zip(materials, expected_materials))
 
 @pytest.fixture
 def general_cylindrical_pinmesh():

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -167,7 +167,7 @@ def test_rectangular_pinmesh_overlary(rectangular_pinmesh, openmc_fuel_material,
     assert all(materials_are_close(material, expected_material)
                for material, expected_material in zip(materials, expected_materials))
 
-    overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000, num_procs=2)
+    overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000)
     materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
     expected_materials = [M, M, M,
                           M, H, M,

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -172,7 +172,6 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
                           M, H, M,
                           M, M, M] * 3
 
-    assert(False)
     assert all(materials_are_close(material, expected_material)
                for material, expected_material in zip(materials, expected_materials))
 

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -157,6 +157,7 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
     M       = Material.from_openmc_material(openmc_moderator_material)
     H       = Material.mix_materials([F, M], [fuel_frac, mod_frac], Material.MixPolicy(percent_type='vo'))
 
+    print("Here 1")
     overlay_policy = PinMesh.OverlayPolicy(method="centroid", num_procs=2)
     materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
     assert len(materials) == pinmesh.number_of_material_regions
@@ -167,6 +168,7 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
     assert all(materials_are_close(material, expected_material)
                for material, expected_material in zip(materials, expected_materials))
 
+    print("Here 2")
     overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000, num_procs=2)
     materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
     expected_materials = [M, M, M,

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -1,11 +1,8 @@
 import pytest
 from math import isclose, pi
-import shutil
 
 from numpy.testing import assert_allclose
 import openmc
-openmc.config['openmc'] = shutil.which("openmc")
-
 
 from mpactpy.utils import ROUNDING_RELATIVE_TOLERANCE
 from mpactpy import Material
@@ -175,6 +172,7 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
                           M, H, M,
                           M, M, M] * 3
 
+    assert(False)
     assert all(materials_are_close(material, expected_material)
                for material, expected_material in zip(materials, expected_materials))
 

--- a/test/unit/test_pinmesh.py
+++ b/test/unit/test_pinmesh.py
@@ -1,8 +1,10 @@
 import pytest
 from math import isclose, pi
+import shutil
 
 from numpy.testing import assert_allclose
 import openmc
+openmc.config['openmc'] = shutil.which("openmc")
 
 
 from mpactpy.utils import ROUNDING_RELATIVE_TOLERANCE
@@ -157,7 +159,6 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
     M       = Material.from_openmc_material(openmc_moderator_material)
     H       = Material.mix_materials([F, M], [fuel_frac, mod_frac], Material.MixPolicy(percent_type='vo'))
 
-    print("Here 1", flush=True)
     overlay_policy = PinMesh.OverlayPolicy(method="centroid", num_procs=2)
     materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
     assert len(materials) == pinmesh.number_of_material_regions
@@ -168,7 +169,6 @@ def test_rectangular_pinmesh_overlay(rectangular_pinmesh, openmc_fuel_material, 
     assert all(materials_are_close(material, expected_material)
                for material, expected_material in zip(materials, expected_materials))
 
-    print("Here 2", flush=True)
     overlay_policy = PinMesh.OverlayPolicy(method="homogenized", n_samples=100000, num_procs=2)
     materials = pinmesh.overlay(model=openmc_pin, offset=offset, overlay_policy=overlay_policy)
     expected_materials = [M, M, M,


### PR DESCRIPTION
Adds an overlay operation where an OpenMC geometry can be selectively overlain on to MPACT geometry elements.  Includes other minor fixes and revisions to support this new overlay operation.

Closes #27 